### PR TITLE
feat: add simple server mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,16 @@ The live server uses ports 3737-3747 and automatically finds an available port.
 - Live preview is available for `svg` format only; PNG/PDF are rendered without live reload.
 - For sequence diagrams, Mermaid does not support `style` directives inside `sequenceDiagram`.
 
+## 🖥️ Standalone server
+
+You can start the preview server without an AI agent using the `--serve` flag:
+
+```bash
+claude-mermaid --serve
+```
+
+This opens the diagram gallery in your browser with all previously rendered diagrams. Useful for browsing and exporting diagrams outside of a Claude Code session.
+
 ## 🛠️ Development
 
 ```bash

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -145,6 +145,14 @@ export function validateSavePath(savePath: string): void {
   }
 }
 
+export function getOpenCommand(): string {
+  return process.platform === "darwin"
+    ? "open"
+    : process.platform === "win32"
+      ? "start"
+      : "xdg-open";
+}
+
 export async function cleanupOldDiagrams(
   maxAgeMs: number = TIMEOUTS.CLEANUP_MAX_AGE_MS
 ): Promise<number> {

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -11,6 +11,7 @@ import {
   loadDiagramSource,
   loadDiagramOptions,
   validateSavePath,
+  getOpenCommand,
 } from "./file-utils.js";
 import { mcpLogger } from "./logger.js";
 
@@ -25,14 +26,6 @@ interface RenderOptions {
   width: number;
   height: number;
   scale: number;
-}
-
-function getOpenCommand(): string {
-  return process.platform === "darwin"
-    ? "open"
-    : process.platform === "win32"
-      ? "start"
-      : "xdg-open";
 }
 
 async function renderDiagram(options: RenderOptions, liveFilePath: string): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,13 @@ if (process.argv.includes("-v") || process.argv.includes("--version")) {
   process.exit(0);
 }
 
+const isServeMode = process.argv.includes("--serve");
+
+if (isServeMode) {
+  const { startServeMode } = await import("./serve.js");
+  await startServeMode();
+}
+
 const TOOL_DEFINITIONS: Tool[] = [
   {
     name: "mermaid_preview",
@@ -174,11 +181,13 @@ async function main() {
   console.error("Claude Mermaid MCP Server running on stdio");
 }
 
-main().catch((error) => {
-  mcpLogger.error("Fatal error during startup", {
-    error: error instanceof Error ? error.message : String(error),
-    stack: error instanceof Error ? error.stack : undefined,
+if (!isServeMode) {
+  main().catch((error) => {
+    mcpLogger.error("Fatal error during startup", {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    console.error("Fatal error:", error);
+    process.exit(1);
   });
-  console.error("Fatal error:", error);
-  process.exit(1);
-});
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -1,0 +1,52 @@
+/**
+ * Standalone server mode (--serve)
+ * Starts the live server without the MCP stdio transport,
+ * registers existing diagrams, and opens the gallery in the browser.
+ */
+
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { readdir, access } from "fs/promises";
+import { join } from "path";
+import { ensureLiveServer, addLiveDiagram } from "./live-server.js";
+import { getLiveDir, getOpenCommand } from "./file-utils.js";
+import { FILE_NAMES } from "./constants.js";
+
+const execFileAsync = promisify(execFile);
+
+async function registerExistingDiagrams(): Promise<number> {
+  const liveDir = getLiveDir();
+  let registered = 0;
+
+  let entries;
+  try {
+    entries = await readdir(liveDir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    const svgPath = join(liveDir, entry.name, FILE_NAMES.DIAGRAM_SVG);
+    try {
+      await access(svgPath);
+      await addLiveDiagram(entry.name, svgPath);
+      registered++;
+    } catch {
+      // Skip directories without a rendered SVG
+    }
+  }
+
+  return registered;
+}
+
+export async function startServeMode(): Promise<void> {
+  const diagramCount = await registerExistingDiagrams();
+  const port = await ensureLiveServer();
+  const galleryUrl = `http://localhost:${port}/`;
+
+  console.log(`Serving ${diagramCount} diagram(s) at ${galleryUrl}`);
+
+  await execFileAsync(getOpenCommand(), [galleryUrl]);
+}

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn((_cmd: string, _args: string[], cb: Function) => cb(null)),
+}));
+
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    readdir: vi.fn(),
+    access: vi.fn(),
+  };
+});
+
+vi.mock("../src/live-server.js", () => ({
+  ensureLiveServer: vi.fn().mockResolvedValue(3737),
+  addLiveDiagram: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { readdir, access } from "fs/promises";
+import { ensureLiveServer, addLiveDiagram } from "../src/live-server.js";
+import { startServeMode } from "../src/serve.js";
+
+const mockReaddir = vi.mocked(readdir);
+const mockAccess = vi.mocked(access);
+const mockEnsureLiveServer = vi.mocked(ensureLiveServer);
+const mockAddLiveDiagram = vi.mocked(addLiveDiagram);
+
+describe("startServeMode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnsureLiveServer.mockResolvedValue(3737);
+  });
+
+  it("starts the live server and opens the gallery", async () => {
+    mockReaddir.mockResolvedValue([] as any);
+
+    await startServeMode();
+
+    expect(mockEnsureLiveServer).toHaveBeenCalled();
+  });
+
+  it("registers existing diagrams that have an SVG file", async () => {
+    mockReaddir.mockResolvedValue([
+      { name: "flow", isDirectory: () => true },
+      { name: "arch", isDirectory: () => true },
+    ] as any);
+    mockAccess.mockResolvedValue(undefined);
+
+    await startServeMode();
+
+    expect(mockAddLiveDiagram).toHaveBeenCalledTimes(2);
+    expect(mockAddLiveDiagram).toHaveBeenCalledWith("flow", expect.stringContaining("diagram.svg"));
+    expect(mockAddLiveDiagram).toHaveBeenCalledWith("arch", expect.stringContaining("diagram.svg"));
+  });
+
+  it("skips directories without an SVG file", async () => {
+    mockReaddir.mockResolvedValue([
+      { name: "good", isDirectory: () => true },
+      { name: "bad", isDirectory: () => true },
+    ] as any);
+    mockAccess.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error("ENOENT"));
+
+    await startServeMode();
+
+    expect(mockAddLiveDiagram).toHaveBeenCalledTimes(1);
+    expect(mockAddLiveDiagram).toHaveBeenCalledWith("good", expect.stringContaining("diagram.svg"));
+  });
+
+  it("skips non-directory entries", async () => {
+    mockReaddir.mockResolvedValue([{ name: "file.txt", isDirectory: () => false }] as any);
+
+    await startServeMode();
+
+    expect(mockAddLiveDiagram).not.toHaveBeenCalled();
+  });
+
+  it("handles empty live directory gracefully", async () => {
+    mockReaddir.mockRejectedValue(new Error("ENOENT"));
+
+    await startServeMode();
+
+    expect(mockAddLiveDiagram).not.toHaveBeenCalled();
+    expect(mockEnsureLiveServer).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Sometimes there is a need to open the existed diagrams without using LLM. Now it is possible:

```
claude-mermaid --serve
```