### PR TITLE
chore(ci): add node 25.x to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [20.x, 22.x, 24.x, 25.x]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- [x] Add Node.js 25.x (current release) to CI test matrix

CI now tests against: 20.x, 22.x, 24.x, 25.x