### PR TITLE
ci: add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,30 @@
+name: HOL Skill Validate
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate Skill
+        uses: hashgraph-online/skill-publish@47895cf40f6214511c713628dbbafd0c3316f4dd
+        with:
+          mode: validate
+          skill-dir: skills/mermaid-diagrams
+          annotate: "false"
+          preview-upload: "false"


### PR DESCRIPTION
Adds a workflow that validates skill metadata in the repo.

- Includes a skill for diagram best practices
- Exposes a `claude-mermaid` command
- Can generate ER diagrams as PDF

The workflow runs the skill validator in validate mode — it checks schema and trust signals but doesn't modify anything or touch runtime code.

Happy to adjust the workflow filename or target directory if you'd prefer a different structure.