### PR TITLE
Fix Windows browser-open crash (`spawn start ENOENT`) in MCP and --serve paths

### DIFF
--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -158,10 +158,18 @@ export function validateSavePath(savePath: string): void {
   }
 }
 
-export function getOpenCommand(): string {
-  return process.platform === "darwin"
-    ? "open"
-    : process.platform === "win32"
-      ? "start"
-      : "xdg-open";
+export interface OpenCommand {
+  command: string;
+  args: string[];
+}
+
+export function getOpenCommand(url: string): OpenCommand {
+  switch (process.platform) {
+    case "darwin":
+      return { command: "open", args: [url] };
+    case "win32":
+      return { command: "cmd.exe", args: ["/c", "start", "", url] };
+    default:
+      return { command: "xdg-open", args: [url] };
+  }
 }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -104,8 +104,19 @@ async function setupLivePreview(
 
   if (!hasConnections) {
     mcpLogger.info(`Opening browser for new diagram: ${previewId}`, { serverUrl });
-    const openCommand = getOpenCommand();
-    const child = spawn(openCommand, [serverUrl], { detached: true, stdio: "ignore" });
+    // On Windows, `getOpenCommand()` returns the cmd.exe builtin `start`,
+    // which `spawn` cannot launch directly — it emits an asynchronous `error`
+    // event that, with no listener attached, crashes the MCP server.
+    // Route through `cmd /c start` (mirroring the npx-on-Windows pattern in
+    // `renderDiagram` above), and attach an `error` listener so a failed
+    // browser-open is best-effort and never aborts the server.
+    const isWin = process.platform === "win32";
+    const openCommand = isWin ? "cmd.exe" : getOpenCommand();
+    const openArgs = isWin ? ["/c", "start", "", serverUrl] : [serverUrl];
+    const child = spawn(openCommand, openArgs, { detached: true, stdio: "ignore" });
+    child.on("error", () => {
+      // Best-effort: log nothing extra; the diagram itself rendered fine.
+    });
     child.unref();
   } else {
     mcpLogger.info(`Reusing existing browser tab for diagram: ${previewId}`);

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -104,18 +104,10 @@ async function setupLivePreview(
 
   if (!hasConnections) {
     mcpLogger.info(`Opening browser for new diagram: ${previewId}`, { serverUrl });
-    // On Windows, `getOpenCommand()` returns the cmd.exe builtin `start`,
-    // which `spawn` cannot launch directly — it emits an asynchronous `error`
-    // event that, with no listener attached, crashes the MCP server.
-    // Route through `cmd /c start` (mirroring the npx-on-Windows pattern in
-    // `renderDiagram` above), and attach an `error` listener so a failed
-    // browser-open is best-effort and never aborts the server.
-    const isWin = process.platform === "win32";
-    const openCommand = isWin ? "cmd.exe" : getOpenCommand();
-    const openArgs = isWin ? ["/c", "start", "", serverUrl] : [serverUrl];
-    const child = spawn(openCommand, openArgs, { detached: true, stdio: "ignore" });
-    child.on("error", () => {
-      // Best-effort: log nothing extra; the diagram itself rendered fine.
+    const { command, args } = getOpenCommand(serverUrl);
+    const child = spawn(command, args, { detached: true, stdio: "ignore" });
+    child.on("error", (error) => {
+      mcpLogger.warn("Failed to open browser", { error: error.message, serverUrl });
     });
     child.unref();
   } else {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -48,16 +48,10 @@ export async function startServeMode(): Promise<void> {
 
   console.log(`Serving ${diagramCount} diagram(s) at ${galleryUrl}`);
 
-  // Opening the browser is best-effort — a failure must not bring down
-  // `--serve`. On Windows, `getOpenCommand()` returns `start`, a cmd.exe
-  // builtin that `execFile` cannot launch directly; route through `cmd /c`.
+  const { command, args } = getOpenCommand(galleryUrl);
   try {
-    if (process.platform === "win32") {
-      await execFileAsync("cmd.exe", ["/c", "start", "", galleryUrl]);
-    } else {
-      await execFileAsync(getOpenCommand(), [galleryUrl]);
-    }
+    await execFileAsync(command, args);
   } catch {
-    // Ignored — server is up; the user can navigate to the URL manually.
+    console.warn(`Could not open browser automatically. Open ${galleryUrl} manually.`);
   }
 }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -48,5 +48,16 @@ export async function startServeMode(): Promise<void> {
 
   console.log(`Serving ${diagramCount} diagram(s) at ${galleryUrl}`);
 
-  await execFileAsync(getOpenCommand(), [galleryUrl]);
+  // Opening the browser is best-effort — a failure must not bring down
+  // `--serve`. On Windows, `getOpenCommand()` returns `start`, a cmd.exe
+  // builtin that `execFile` cannot launch directly; route through `cmd /c`.
+  try {
+    if (process.platform === "win32") {
+      await execFileAsync("cmd.exe", ["/c", "start", "", galleryUrl]);
+    } else {
+      await execFileAsync(getOpenCommand(), [galleryUrl]);
+    }
+  } catch {
+    // Ignored — server is up; the user can navigate to the URL manually.
+  }
 }


### PR DESCRIPTION
Fixes #129.

## What

On Windows, `getOpenCommand()` returns the bare string `"start"`. `start` is a `cmd.exe` builtin, not an executable, so both `execFile("start", …)` (in `--serve`) and `spawn("start", …)` (in the MCP path) fail with `spawn start ENOENT`. The errors are unhandled, so:

- the MCP server process exits 1 immediately after every `mermaid_preview` call that opens a browser, and
- `claude-mermaid --serve` exits before serving a single request.

See the issue for the full reproduction (isolated mechanism + end-to-end MCP transcript).

## Fix

Route the browser-open through `cmd.exe /c start` on Windows — the same pattern this codebase already uses for `npx` in `handlers.ts` (see the `CVE-2024-27980` comment). Make browser-open non-fatal in both paths: the diagram render is the contract, opening a browser is best-effort.

- `src/handlers.ts` (`setupLivePreview`): on Windows, spawn `cmd /c start "" <url>`; attach an `error` listener so a failed launch never raises an unhandled `error` event.
- `src/serve.ts` (`startServeMode`): same Windows branch via `execFileAsync`, wrapped in `try`/`catch` so a failed launch never aborts `--serve`.

The empty `""` second argument to `start` is the canonical title placeholder — it prevents `start` from treating a quoted URL as a window title.

## Verification

End-to-end MCP server test on Windows (Node 24.14.1) — same harness that reproduced the crash in #129:

**Before:** `RESULT: MCP server process DIED.  exit code = 1, signal = null` — `spawn start ENOENT`
**After:** `RESULT: MCP server process is STILL ALIVE after the tool call. No crash.`

`claude-mermaid --serve` no longer crashes on startup and serves the gallery as expected.

No behavior change on macOS/Linux.
