### PR TITLE
fix: bind live reload server to loopback only

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,10 @@ export const APP_NAME = "claude-mermaid";
 // ===== Server Configuration =====
 export const SERVER_PORT_START = 3737;
 export const SERVER_PORT_END = 3747;
+// Bind to loopback only — this is a local developer tool with no auth,
+// and binding to all interfaces would expose the unauthenticated
+// gallery + DELETE /api/diagrams endpoints to anyone on the LAN.
+export const SERVER_HOST = "127.0.0.1";
 
 // ===== File Names =====
 export const FILE_NAMES = {

--- a/src/live-server.ts
+++ b/src/live-server.ts
@@ -20,6 +20,7 @@ import {
   CSP_HEADER,
   SERVER_PORT_START,
   SERVER_PORT_END,
+  SERVER_HOST,
   ROUTES,
   CONTENT_TYPES,
   CACHE_CONTROL,
@@ -53,7 +54,7 @@ async function findAvailablePort(
         testServer.once("listening", () => {
           testServer.close(() => resolve());
         });
-        testServer.listen(port);
+        testServer.listen(port, SERVER_HOST);
       });
       return port;
     } catch (error) {
@@ -349,10 +350,10 @@ export async function ensureLiveServer(): Promise<number> {
   });
 
   await new Promise<void>((resolve) => {
-    liveServer!.listen(port, () => {
+    liveServer!.listen(port, SERVER_HOST, () => {
       liveServerPort = port;
-      webLogger.info(`Live reload server listening on port ${port}`);
-      console.error(`Live reload server started on port ${port}`);
+      webLogger.info(`Live reload server listening on ${SERVER_HOST}:${port}`);
+      console.error(`Live reload server started on ${SERVER_HOST}:${port}`);
       resolve();
     });
   });

--- a/test/live-server/server-setup.ts
+++ b/test/live-server/server-setup.ts
@@ -25,9 +25,10 @@ class FakeServer {
     this.events.set(event, callback);
   }
 
-  listen(port: number, callback?: () => void) {
+  listen(port: number, hostOrCallback?: string | (() => void), callback?: () => void) {
     state.port = port;
-    callback?.();
+    const cb = typeof hostOrCallback === "function" ? hostOrCallback : callback;
+    cb?.();
     this.events.get("listening")?.();
   }
 


### PR DESCRIPTION
## Overview

- [x] bind live reload server to `127.0.0.1` instead of all interfaces (Node default)
- [x] apply host binding to both port probe in `findAvailablePort` and the main `ensureLiveServer` listen call
- [x] include host in startup log messages
- [x] update `FakeServer` test mock to accept Node's `(port, host?, callback?)` signature

## Why

The live reload server has no authentication and exposes a gallery UI plus a `DELETE /api/diagrams` endpoint. With the previous default bind, these were reachable to anyone on the local network. Restricting to loopback keeps the tool local-only, as intended.