### PR TITLE
fix: validate diagram ID in /view route to prevent path traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Bind live reload server to `127.0.0.1` to prevent LAN exposure of the unauthenticated gallery and `DELETE /api/diagrams` endpoint (#135)
+- Validate diagram ID in `/view/` route to prevent path traversal in `handleViewRequest`
 - Bumped `qs` transitive dependency to 6.15.2
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Validate diagram ID in `/view/` route to prevent path traversal in `handleViewRequest`
+
 ## [1.6.4] - 2026-05-28
 
 ### Security
 
 - Bind live reload server to `127.0.0.1` to prevent LAN exposure of the unauthenticated gallery and `DELETE /api/diagrams` endpoint (#135)
-- Validate diagram ID in `/view/` route to prevent path traversal in `handleViewRequest`
 - Bumped `qs` transitive dependency to 6.15.2
 
 ### Fixed

--- a/src/live-server.ts
+++ b/src/live-server.ts
@@ -65,7 +65,22 @@ async function findAvailablePort(
 }
 
 async function handleViewRequest(url: string, res: ServerResponse, port: number): Promise<void> {
-  const diagramId = url.substring(6);
+  const rawId = url.substring(ROUTES.VIEW.length);
+
+  let diagramId: string;
+  try {
+    diagramId = decodeURIComponent(rawId);
+    validatePreviewId(diagramId);
+  } catch (error) {
+    webLogger.warn("Invalid view request", {
+      rawId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    res.writeHead(400, { "Content-Type": CONTENT_TYPES.PLAIN });
+    res.end("Invalid diagram ID");
+    return;
+  }
+
   const filePath = join(getLiveDir(), diagramId, "diagram.svg");
 
   webLogger.debug(`View request for diagram: ${diagramId}`);

--- a/test/live-server/http-responses.test.ts
+++ b/test/live-server/http-responses.test.ts
@@ -93,4 +93,38 @@ describe("Live server responses", () => {
     const payload = await response.json();
     expect(payload.error).toBe("Diagram not found");
   });
+
+  it("serves /view for a valid diagram ID", async () => {
+    const port = await ensureLiveServer();
+    const diagramId = "view-test";
+
+    const diagramDir = join(configDir, "claude-mermaid", "live", diagramId);
+    await mkdir(diagramDir, { recursive: true });
+    await writeFile(join(diagramDir, "diagram.svg"), "<svg>view</svg>", "utf-8");
+    await writeFile(
+      join(diagramDir, "options.json"),
+      JSON.stringify(DEFAULT_DIAGRAM_OPTIONS),
+      "utf-8"
+    );
+
+    const response = await mockFetch(`http://localhost:${port}/view/${diagramId}`);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/html");
+  });
+
+  it("rejects /view path traversal attempts", async () => {
+    const port = await ensureLiveServer();
+    const response = await mockFetch(`http://localhost:${port}/view/../../etc/passwd`);
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("Invalid diagram ID");
+  });
+
+  it("rejects /view URL-encoded path traversal", async () => {
+    const port = await ensureLiveServer();
+    const response = await mockFetch(
+      `http://localhost:${port}/view/%2e%2e%2f%2e%2e%2fetc%2fpasswd`
+    );
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("Invalid diagram ID");
+  });
 });


### PR DESCRIPTION
## Summary

- `handleViewRequest` used the raw URL substring as a path segment, letting requests like `/view/../../etc/passwd/diagram.svg` escape `getLiveDir()` (CWE-22).
- Add `decodeURIComponent` + `validatePreviewId` gating before constructing `filePath`, matching the existing pattern in `handleExportPngRequest` and `handleMermaidLiveRequest`.
- Add tests for the `/view/` route: happy path, `..`-based traversal, URL-encoded traversal.
- Update the unreleased 1.6.4 changelog entry.

## Why this is a real issue

CodeQL alerts [#4](https://github.com/veelenga/claude-mermaid/security/code-scanning/4) and [#5](https://github.com/veelenga/claude-mermaid/security/code-scanning/5) both trace `req.url` → `handleViewRequest`. The hardcoded `/diagram.svg` suffix limits the surface (attacker can only read files literally named `diagram.svg`), but it is still a path-traversal info leak. Since the live server is now bound to `127.0.0.1` (commit d30cd7e), the reach is local-only, but DNS-rebinding / cross-origin trigger paths still apply.

## Test plan

- [x] `npx vitest run test/live-server/http-responses.test.ts` — all 7 tests pass (4 existing + 3 new)
- [x] `npx vitest run` — full suite: 177/177 pass
- [x] `prettier --check` on modified files — clean
- [ ] Verify CodeQL re-scan closes alerts #4 and #5 after merge