### PR TITLE
chore(ci): restrict GITHUB_TOKEN to contents:read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Declare an explicit top-level `permissions: contents: read` block in `.github/workflows/ci.yml`.
- Both jobs (`test`, `lint`) only `checkout` + `setup-node` + run npm scripts — no GitHub API writes — so `contents: read` is the minimum needed for `actions/checkout`.
- Closes CodeQL `actions/missing-workflow-permissions` alerts [#1](https://github.com/veelenga/claude-mermaid/security/code-scanning/1) and [#2](https://github.com/veelenga/claude-mermaid/security/code-scanning/2).

## Why this matters

Without an explicit `permissions` block, the workflow inherits the repo/org default, which is historically read-write. Locking the `GITHUB_TOKEN` to `contents: read` limits blast radius if a transitive action ever gets compromised, and freezes the permission set even if the repo default changes later (principle of least privilege, CWE-275).

## Test plan

- [ ] CI runs green on this branch (workflows still clone, install, test, build, format-check, tsc).
- [ ] CodeQL re-scan auto-closes alerts #1 and #2.