### PR TITLE
fix(website): make landing page mobile friendly

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1514,12 +1514,11 @@ graph LR
           const render = async () => {
             mermaid.initialize({
               startOnLoad: false,
-              securityLevel: "loose",
               theme: prefersDark.matches ? "dark" : "default",
               fontFamily: 'ui-monospace, "SF Mono", Menlo, Consolas, monospace',
             });
             el.removeAttribute("data-processed");
-            el.innerHTML = source;
+            el.textContent = source;
             await mermaid.run({ nodes: [el] });
           };
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -339,6 +339,11 @@
           gap: 56px;
         }
       }
+      .hero-grid > *,
+      .steps li > *,
+      .feat-grid > * {
+        min-width: 0;
+      }
       .eyebrow {
         font-family: var(--font-mono);
         font-size: 13px;
@@ -447,7 +452,6 @@
       }
       .term-body p {
         margin: 0 0 2px;
-        white-space: pre-wrap;
       }
       .term-body .spacer {
         height: 12px;
@@ -482,9 +486,10 @@
         top: 9px;
         right: 9px;
         display: none;
-        background: rgba(255, 255, 255, 0.08);
+        background: #33322d;
         color: #d9d5cb;
-        border: 1px solid rgba(255, 255, 255, 0.12);
+        border: 1px solid rgba(255, 255, 255, 0.18);
+        box-shadow: -6px 0 10px -2px var(--term-bg);
         border-radius: 7px;
         padding: 5px 9px;
         font-size: 12px;
@@ -495,7 +500,7 @@
         display: inline-block;
       }
       .copy:hover {
-        background: rgba(255, 255, 255, 0.16);
+        background: #45443d;
       }
       .copy.done {
         color: #7bd88f;

--- a/docs/index.html
+++ b/docs/index.html
@@ -974,8 +974,7 @@ graph LR
     D --> F[Try again]
     classDef ok stroke:#28c840;
     class C,E ok;
-</pre
-                >
+</pre>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Overview

- [x] fix horizontal overflow at phone widths: grid items (`.hero-grid`, `.steps li`, `.feat-grid`) now get `min-width: 0` so long `pre` command lines scroll inside their blocks instead of stretching the page to ~490px
- [x] fix the terminal-exchange block rendering source indentation literally (`white-space: pre-wrap` on `.term-body p`) — prompt lines now wrap naturally at any width
- [x] make the Copy button opaque with a soft fade so scrolled code no longer shows through it
- [x] reformat with prettier 3.9.4 to match CI
- [x] resolve CodeQL alert #6 (`js/xss-through-dom`): restore the hero diagram source with `textContent` instead of `innerHTML`, and drop `securityLevel: "loose"` in favor of Mermaid's strict default

Verified at 390px viewport: page scroll width now equals viewport width, and every section (hero, live diagram, steps, terminal, features, install tabs, tool tables, FAQ, footer) renders cleanly. The live Mermaid diagram verified rendering correctly under strict security level.