### PR TITLE
Add allowlist validation for theme/format params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Validate theme, format, width, height and scale before rendering to prevent command injection via `cmd.exe /c` on Windows; re-render paths (`mermaid_save`, `/export/`) are validated too
+
 ## [1.6.5] - 2026-08-08
 
 ### Security

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -100,13 +100,6 @@ export const PREVIEW_ID_REGEX = /^[a-zA-Z0-9_-]+$/;
 export const BACKGROUND_REGEX =
   /^(?:[a-zA-Z]+|#[0-9a-fA-F]{3,8}|(?:rgb|rgba|hsl|hsla)\(\s*[0-9.,%\s]+\s*\))$/;
 
-// Strict allowlists for theme/format. These values are passed verbatim into
-// the mermaid-cli child argv (e.g. `-t <theme>`, `-o diagram-<id>.<format>`)
-// and on Windows that argv runs through `cmd.exe /c`, which re-parses `&`,
-// `|`, `&&`, `||`, etc. as command separators. The MCP tool's inputSchema
-// declares matching `enum` values, but that only constrains the AI caller —
-// the server must enforce it too (never trust schema validation as a
-// security boundary). See: CWE-78.
 export const ALLOWED_THEMES = ["default", "forest", "dark", "neutral"] as const;
 export const ALLOWED_FORMATS = ["svg", "png", "pdf"] as const;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -100,6 +100,16 @@ export const PREVIEW_ID_REGEX = /^[a-zA-Z0-9_-]+$/;
 export const BACKGROUND_REGEX =
   /^(?:[a-zA-Z]+|#[0-9a-fA-F]{3,8}|(?:rgb|rgba|hsl|hsla)\(\s*[0-9.,%\s]+\s*\))$/;
 
+// Strict allowlists for theme/format. These values are passed verbatim into
+// the mermaid-cli child argv (e.g. `-t <theme>`, `-o diagram-<id>.<format>`)
+// and on Windows that argv runs through `cmd.exe /c`, which re-parses `&`,
+// `|`, `&&`, `||`, etc. as command separators. The MCP tool's inputSchema
+// declares matching `enum` values, but that only constrains the AI caller —
+// the server must enforce it too (never trust schema validation as a
+// security boundary). See: CWE-78.
+export const ALLOWED_THEMES = ["default", "forest", "dark", "neutral"] as const;
+export const ALLOWED_FORMATS = ["svg", "png", "pdf"] as const;
+
 // ===== System Paths (Security) =====
 export const UNIX_SYSTEM_PATHS = [
   "/etc",

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -12,7 +12,7 @@ import {
   ALLOWED_THEMES,
   ALLOWED_FORMATS,
 } from "./constants.js";
-import type { DiagramOptions } from "./types.js";
+import type { DiagramOptions, RenderOptions } from "./types.js";
 
 export function getConfigDir(): string {
   const xdg = process.env.XDG_CONFIG_HOME;
@@ -59,32 +59,33 @@ export function validateBackground(background: string): void {
   }
 }
 
-/**
- * Validates that a theme string is an allowed value. The theme is passed
- * verbatim into the mermaid-cli argv (`-t <theme>`), which on Windows runs
- * through `cmd.exe /c` — a non-allowlisted value carrying shell
- * metacharacters would be interpreted as a command separator (CWE-78).
- */
-export function validateTheme(theme: string): void {
-  if (!theme || !(ALLOWED_THEMES as readonly string[]).includes(theme)) {
-    throw new Error(
-      `Invalid theme: "${theme}". Allowed values: ${ALLOWED_THEMES.join(", ")}.`
-    );
+function validateAllowed(label: string, value: string, allowed: readonly string[]): void {
+  if (!allowed.includes(value)) {
+    throw new Error(`Invalid ${label}: "${value}". Allowed values: ${allowed.join(", ")}.`);
   }
 }
 
-/**
- * Validates that a format string is an allowed value. The format is used to
- * build the output file path (`diagram-<id>.<format>`) which is passed into
- * the mermaid-cli argv (`-o <path>`), running through `cmd.exe /c` on
- * Windows — a non-allowlisted value could inject shell commands (CWE-78).
- */
+export function validateTheme(theme: string): void {
+  validateAllowed("theme", theme, ALLOWED_THEMES);
+}
+
 export function validateFormat(format: string): void {
-  if (!format || !(ALLOWED_FORMATS as readonly string[]).includes(format)) {
-    throw new Error(
-      `Invalid format: "${format}". Allowed values: ${ALLOWED_FORMATS.join(", ")}.`
-    );
+  validateAllowed("format", format, ALLOWED_FORMATS);
+}
+
+export function validateDimension(label: string, value: number): void {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`Invalid ${label}: "${value}". Must be a positive number.`);
   }
+}
+
+export function validateRenderOptions(options: RenderOptions): void {
+  validateFormat(options.format);
+  validateTheme(options.theme);
+  validateBackground(options.background);
+  validateDimension("width", options.width);
+  validateDimension("height", options.height);
+  validateDimension("scale", options.scale);
 }
 
 export function getPreviewDir(previewId: string): string {

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -9,6 +9,8 @@ import {
   WINDOWS_SYSTEM_PATHS,
   FILE_NAMES,
   DIR_NAMES,
+  ALLOWED_THEMES,
+  ALLOWED_FORMATS,
 } from "./constants.js";
 import type { DiagramOptions } from "./types.js";
 
@@ -53,6 +55,34 @@ export function validateBackground(background: string): void {
   if (!background || !BACKGROUND_REGEX.test(background)) {
     throw new Error(
       "Invalid background color. Use a CSS named color (e.g. 'transparent'), hex (e.g. '#F0F0F0'), or rgb/rgba/hsl/hsla(...)."
+    );
+  }
+}
+
+/**
+ * Validates that a theme string is an allowed value. The theme is passed
+ * verbatim into the mermaid-cli argv (`-t <theme>`), which on Windows runs
+ * through `cmd.exe /c` — a non-allowlisted value carrying shell
+ * metacharacters would be interpreted as a command separator (CWE-78).
+ */
+export function validateTheme(theme: string): void {
+  if (!theme || !(ALLOWED_THEMES as readonly string[]).includes(theme)) {
+    throw new Error(
+      `Invalid theme: "${theme}". Allowed values: ${ALLOWED_THEMES.join(", ")}.`
+    );
+  }
+}
+
+/**
+ * Validates that a format string is an allowed value. The format is used to
+ * build the output file path (`diagram-<id>.<format>`) which is passed into
+ * the mermaid-cli argv (`-o <path>`), running through `cmd.exe /c` on
+ * Windows — a non-allowlisted value could inject shell commands (CWE-78).
+ */
+export function validateFormat(format: string): void {
+  if (!format || !(ALLOWED_FORMATS as readonly string[]).includes(format)) {
+    throw new Error(
+      `Invalid format: "${format}". Allowed values: ${ALLOWED_FORMATS.join(", ")}.`
     );
   }
 }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -12,6 +12,8 @@ import {
   loadDiagramOptions,
   validateBackground,
   validateSavePath,
+  validateTheme,
+  validateFormat,
   getOpenCommand,
 } from "./file-utils.js";
 import { mcpLogger } from "./logger.js";
@@ -170,13 +172,15 @@ export async function handleMermaidPreview(args: any) {
   }
 
   try {
+    validateFormat(format);
+    validateTheme(theme);
     validateBackground(background);
   } catch (error) {
     return {
       content: [
         {
           type: "text",
-          text: `Invalid background: ${error instanceof Error ? error.message : String(error)}`,
+          text: `Invalid parameter: ${error instanceof Error ? error.message : String(error)}`,
         },
       ],
       isError: true,
@@ -238,6 +242,25 @@ export async function handleMermaidSave(args: any) {
         {
           type: "text",
           text: `Invalid save path: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  // Validate format to prevent command injection via cmd.exe /c on Windows
+  try {
+    validateFormat(format);
+  } catch (error) {
+    mcpLogger.error("Format validation failed", {
+      format,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Invalid format: ${error instanceof Error ? error.message : String(error)}`,
         },
       ],
       isError: true,

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -10,28 +10,18 @@ import {
   saveDiagramSource,
   loadDiagramSource,
   loadDiagramOptions,
-  validateBackground,
   validateSavePath,
-  validateTheme,
   validateFormat,
+  validateRenderOptions,
   getOpenCommand,
 } from "./file-utils.js";
 import { mcpLogger } from "./logger.js";
+import type { RenderOptions } from "./types.js";
 
 const execFileAsync = promisify(execFile);
 
-export interface RenderOptions {
-  diagram: string;
-  previewId: string;
-  format: string;
-  theme: string;
-  background: string;
-  width: number;
-  height: number;
-  scale: number;
-}
-
 export async function renderDiagram(options: RenderOptions, liveFilePath: string): Promise<void> {
+  validateRenderOptions(options);
   const { diagram, previewId, format, theme, background, width, height, scale } = options;
 
   mcpLogger.info(`Rendering diagram: ${previewId}`, { format, theme, width, height });
@@ -171,16 +161,16 @@ export async function handleMermaidPreview(args: any) {
     throw new Error("preview_id parameter is required");
   }
 
+  const renderOptions = { diagram, previewId, format, theme, background, width, height, scale };
+
   try {
-    validateFormat(format);
-    validateTheme(theme);
-    validateBackground(background);
+    validateRenderOptions(renderOptions);
   } catch (error) {
     return {
       content: [
         {
           type: "text",
-          text: `Invalid parameter: ${error instanceof Error ? error.message : String(error)}`,
+          text: error instanceof Error ? error.message : String(error),
         },
       ],
       isError: true,
@@ -193,10 +183,7 @@ export async function handleMermaidPreview(args: any) {
 
   try {
     await saveDiagramSource(previewId, diagram, { theme, background, width, height, scale });
-    await renderDiagram(
-      { diagram, previewId, format, theme, background, width, height, scale },
-      liveFilePath
-    );
+    await renderDiagram(renderOptions, liveFilePath);
 
     if (format === "svg") {
       const { serverUrl, hasConnections } = await setupLivePreview(previewId, liveFilePath);
@@ -248,19 +235,14 @@ export async function handleMermaidSave(args: any) {
     };
   }
 
-  // Validate format to prevent command injection via cmd.exe /c on Windows
   try {
     validateFormat(format);
   } catch (error) {
-    mcpLogger.error("Format validation failed", {
-      format,
-      error: error instanceof Error ? error.message : String(error),
-    });
     return {
       content: [
         {
           type: "text",
-          text: `Invalid format: ${error instanceof Error ? error.message : String(error)}`,
+          text: error instanceof Error ? error.message : String(error),
         },
       ],
       isError: true,
@@ -275,15 +257,7 @@ export async function handleMermaidSave(args: any) {
     } catch {
       const diagram = await loadDiagramSource(previewId);
       const options = await loadDiagramOptions(previewId);
-      await renderDiagram(
-        {
-          diagram,
-          previewId,
-          format,
-          ...options,
-        },
-        liveFilePath
-      );
+      await renderDiagram({ ...options, diagram, previewId, format }, liveFilePath);
     }
 
     const saveDir = dirname(savePath);

--- a/src/live-server.ts
+++ b/src/live-server.ts
@@ -239,7 +239,7 @@ async function handleExportPngRequest(url: string, res: ServerResponse): Promise
     ]);
 
     const pngPath = getDiagramFilePath(diagramId, "png");
-    await renderDiagram({ diagram, previewId: diagramId, format: "png", ...options }, pngPath);
+    await renderDiagram({ ...options, diagram, previewId: diagramId, format: "png" }, pngPath);
 
     const pngData = await readFile(pngPath);
     res.writeHead(200, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,12 @@ export interface DiagramOptions {
   scale: number;
 }
 
+export interface RenderOptions extends DiagramOptions {
+  diagram: string;
+  previewId: string;
+  format: string;
+}
+
 export interface DiagramInfo {
   id: string;
   format: DiagramFormat;

--- a/test/file-utils.test.ts
+++ b/test/file-utils.test.ts
@@ -11,6 +11,8 @@ import {
   getConfigDir,
   validateBackground,
   validateSavePath,
+  validateTheme,
+  validateFormat,
 } from "../src/file-utils.js";
 import { unlink, mkdir, rmdir, readdir, mkdtemp, rm } from "fs/promises";
 import { tmpdir } from "os";
@@ -365,6 +367,62 @@ describe("File Utilities", () => {
       expect(() => validateBackground("#ff")).toThrow("Invalid background color");
       expect(() => validateBackground("rgb(255, 0, 0")).toThrow("Invalid background color");
       expect(() => validateBackground("javascript:alert(1)")).toThrow("Invalid background color");
+    });
+  });
+
+  describe("validateTheme", () => {
+    it("should accept allowed themes", () => {
+      expect(() => validateTheme("default")).not.toThrow();
+      expect(() => validateTheme("forest")).not.toThrow();
+      expect(() => validateTheme("dark")).not.toThrow();
+      expect(() => validateTheme("neutral")).not.toThrow();
+    });
+
+    it("should reject empty or missing values", () => {
+      expect(() => validateTheme("")).toThrow("Invalid theme");
+      expect(() => validateTheme(undefined as unknown as string)).toThrow("Invalid theme");
+    });
+
+    it("should reject shell metacharacters (Windows cmd.exe /c)", () => {
+      // theme flows verbatim into `npx ... -t <theme>` → `cmd.exe /c` on Windows
+      expect(() => validateTheme("default & calc.exe")).toThrow("Invalid theme");
+      expect(() => validateTheme("dark|whoami")).toThrow("Invalid theme");
+      expect(() => validateTheme("default && calc.exe")).toThrow("Invalid theme");
+      expect(() => validateTheme("dark||whoami")).toThrow("Invalid theme");
+      expect(() => validateTheme("default`whoami")).toThrow("Invalid theme");
+    });
+
+    it("should reject values outside the allowlist", () => {
+      expect(() => validateTheme("cyberpunk")).toThrow("Invalid theme");
+      expect(() => validateTheme("DARK")).toThrow("Invalid theme"); // case-sensitive
+      expect(() => validateTheme("default ")).toThrow("Invalid theme"); // trailing space
+    });
+  });
+
+  describe("validateFormat", () => {
+    it("should accept allowed formats", () => {
+      expect(() => validateFormat("svg")).not.toThrow();
+      expect(() => validateFormat("png")).not.toThrow();
+      expect(() => validateFormat("pdf")).not.toThrow();
+    });
+
+    it("should reject empty or missing values", () => {
+      expect(() => validateFormat("")).toThrow("Invalid format");
+      expect(() => validateFormat(undefined as unknown as string)).toThrow("Invalid format");
+    });
+
+    it("should reject shell metacharacters (Windows cmd.exe /c)", () => {
+      // format builds the output path `diagram-<id>.<format>` → `cmd.exe /c`
+      expect(() => validateFormat("svg & calc.exe")).toThrow("Invalid format");
+      expect(() => validateFormat("png|whoami")).toThrow("Invalid format");
+      expect(() => validateFormat("svg&&calc")).toThrow("Invalid format");
+      expect(() => validateFormat("png`id")).toThrow("Invalid format");
+    });
+
+    it("should reject values outside the allowlist", () => {
+      expect(() => validateFormat("jpg")).toThrow("Invalid format");
+      expect(() => validateFormat("SVG")).toThrow("Invalid format"); // case-sensitive
+      expect(() => validateFormat("svg ")).toThrow("Invalid format"); // trailing space
     });
   });
 });

--- a/test/handlers.test.ts
+++ b/test/handlers.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { handleMermaidPreview, handleMermaidSave } from "../src/handlers.js";
-import { getPreviewDir, getDiagramFilePath } from "../src/file-utils.js";
-import { readdir, unlink, access } from "fs/promises";
+import { getPreviewDir, getDiagramFilePath, getDiagramOptionsPath } from "../src/file-utils.js";
+import { readdir, unlink, access, writeFile } from "fs/promises";
 import { execFile } from "child_process";
 import { setupTestEnvWithPreview, restoreTestEnv } from "./helpers/env-helpers.js";
 
@@ -239,6 +239,27 @@ describe("handleMermaidPreview", () => {
     expect(result.content[0].text).toContain("Invalid background");
     expect(mockExecFile).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ["theme", { theme: "dark|whoami" }, "Invalid theme"],
+    ["format", { format: "svg&calc" }, "Invalid format"],
+    ["width", { width: "800&calc" }, "Invalid width"],
+    ["height", { height: -1 }, "Invalid height"],
+    ["scale", { scale: Infinity }, "Invalid scale"],
+  ])("should reject invalid %s without invoking npx", async (_label, overrides, message) => {
+    const mockExecFile = vi.mocked(execFile);
+    mockExecFile.mockClear();
+
+    const result = await handleMermaidPreview({
+      diagram: "graph TD; A-->B",
+      preview_id: testPreviewId,
+      ...overrides,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(message);
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
 });
 
 describe("handleMermaidSave", () => {
@@ -307,6 +328,46 @@ describe("handleMermaidSave", () => {
     const pngPath = getDiagramFilePath(testPreviewId, "png");
     await access(pngPath);
     await unlink(pngPath);
+  });
+
+  it("should reject invalid format without invoking npx", async () => {
+    const mockExecFile = vi.mocked(execFile);
+    mockExecFile.mockClear();
+
+    const result = await handleMermaidSave({
+      save_path: "/tmp/test-diagram.svg",
+      preview_id: testPreviewId,
+      format: "svg&calc",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Invalid format");
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it("should not re-render with tampered stored options", async () => {
+    const mockExecFile = vi.mocked(execFile);
+    mockExecFile.mockClear();
+    await writeFile(
+      getDiagramOptionsPath(testPreviewId),
+      JSON.stringify({
+        theme: "dark & calc.exe",
+        background: "white",
+        width: 800,
+        height: 600,
+        scale: 2,
+      })
+    );
+
+    const result = await handleMermaidSave({
+      save_path: "/tmp/test-diagram.pdf",
+      preview_id: testPreviewId,
+      format: "pdf",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Invalid theme");
+    expect(mockExecFile).not.toHaveBeenCalled();
   });
 
   it("should handle missing diagram source when saving", async () => {


### PR DESCRIPTION
Hi 👋

I noticed the `theme` and `format` params in `mermaid_preview` / `mermaid_save` are taken with only a type assertion + default and no server-side check — the `enum` in `inputSchema` guides the AI caller but isn't enforced by the server itself. In agentic use this could be a mild prompt-injection surface (a steered agent could pass values outside the intended set, and on Windows these flow into the child argv).

This PR adds simple allowlist validation for both, mirroring the existing `validateBackground`:

- `src/constants.ts`: `ALLOWED_THEMES`, `ALLOWED_FORMATS`
- `src/file-utils.ts`: `validateTheme()`, `validateFormat()`
- `src/handlers.ts`: call both before the child process is built
- `test/file-utils.test.ts`: unit tests for the new validators

`tsc --noEmit` is clean and the new tests pass.

Thanks for a genuinely useful tool — I use it with Claude Code a lot. Appreciate you taking the time to review this.