### PR TITLE
refactor: single-source render option enums and defaults

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -100,9 +100,6 @@ export const PREVIEW_ID_REGEX = /^[a-zA-Z0-9_-]+$/;
 export const BACKGROUND_REGEX =
   /^(?:[a-zA-Z]+|#[0-9a-fA-F]{3,8}|(?:rgb|rgba|hsl|hsla)\(\s*[0-9.,%\s]+\s*\))$/;
 
-export const ALLOWED_THEMES = ["default", "forest", "dark", "neutral"] as const;
-export const ALLOWED_FORMATS = ["svg", "png", "pdf"] as const;
-
 // ===== System Paths (Security) =====
 export const UNIX_SYSTEM_PATHS = [
   "/etc",
@@ -154,3 +151,7 @@ export const DIAGRAM_FORMATS = {
 } as const;
 
 export type DiagramFormat = (typeof DIAGRAM_FORMATS)[keyof typeof DIAGRAM_FORMATS];
+
+export const DEFAULT_FORMAT: DiagramFormat = DIAGRAM_FORMATS.SVG;
+export const ALLOWED_FORMATS: readonly DiagramFormat[] = Object.values(DIAGRAM_FORMATS);
+export const ALLOWED_THEMES = ["default", "forest", "dark", "neutral"] as const;

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -80,6 +80,7 @@ export function validateDimension(label: string, value: number): void {
 }
 
 export function validateRenderOptions(options: RenderOptions): void {
+  validatePreviewId(options.previewId);
   validateFormat(options.format);
   validateTheme(options.theme);
   validateBackground(options.background);

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -17,8 +17,17 @@ import {
 } from "./file-utils.js";
 import { mcpLogger } from "./logger.js";
 import type { RenderOptions } from "./types.js";
+import { DEFAULT_DIAGRAM_OPTIONS, DEFAULT_FORMAT } from "./constants.js";
 
 const execFileAsync = promisify(execFile);
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function createErrorResponse(text: string) {
+  return { content: [{ type: "text", text }], isError: true };
+}
 
 export async function renderDiagram(options: RenderOptions, liveFilePath: string): Promise<void> {
   validateRenderOptions(options);
@@ -76,7 +85,7 @@ export async function renderDiagram(options: RenderOptions, liveFilePath: string
     await copyFile(outputFile, liveFilePath);
     mcpLogger.info(`Diagram rendered successfully: ${previewId}`);
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     const stderrValue = error instanceof Error && "stderr" in error ? (error as any).stderr : "";
     const stderr = stderrValue ? `\n${stderrValue}` : "";
     mcpLogger.error(`Diagram rendering failed: ${previewId}`, { error: message });
@@ -147,12 +156,12 @@ function createStaticRenderResponse(liveFilePath: string, format: string): any {
 export async function handleMermaidPreview(args: any) {
   const diagram = args.diagram as string;
   const previewId = args.preview_id as string;
-  const format = (args.format as string) || "svg";
-  const theme = (args.theme as string) || "default";
-  const background = (args.background as string) || "white";
-  const width = (args.width as number) || 800;
-  const height = (args.height as number) || 600;
-  const scale = (args.scale as number) || 2;
+  const format = (args.format as string) ?? DEFAULT_FORMAT;
+  const theme = (args.theme as string) ?? DEFAULT_DIAGRAM_OPTIONS.theme;
+  const background = (args.background as string) ?? DEFAULT_DIAGRAM_OPTIONS.background;
+  const width = (args.width as number) ?? DEFAULT_DIAGRAM_OPTIONS.width;
+  const height = (args.height as number) ?? DEFAULT_DIAGRAM_OPTIONS.height;
+  const scale = (args.scale as number) ?? DEFAULT_DIAGRAM_OPTIONS.scale;
 
   if (!diagram) {
     throw new Error("diagram parameter is required");
@@ -166,15 +175,7 @@ export async function handleMermaidPreview(args: any) {
   try {
     validateRenderOptions(renderOptions);
   } catch (error) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: error instanceof Error ? error.message : String(error),
-        },
-      ],
-      isError: true,
-    };
+    return createErrorResponse(errorMessage(error));
   }
 
   const previewDir = getPreviewDir(previewId);
@@ -192,22 +193,14 @@ export async function handleMermaidPreview(args: any) {
       return createStaticRenderResponse(liveFilePath, format);
     }
   } catch (error) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Error rendering Mermaid diagram: ${error instanceof Error ? error.message : String(error)}`,
-        },
-      ],
-      isError: true,
-    };
+    return createErrorResponse(`Error rendering Mermaid diagram: ${errorMessage(error)}`);
   }
 }
 
 export async function handleMermaidSave(args: any) {
   const savePath = args.save_path as string;
   const previewId = args.preview_id as string;
-  const format = (args.format as string) || "svg";
+  const format = (args.format as string) ?? DEFAULT_FORMAT;
 
   if (!savePath) {
     throw new Error("save_path parameter is required");
@@ -222,31 +215,15 @@ export async function handleMermaidSave(args: any) {
   } catch (error) {
     mcpLogger.error("Save path validation failed", {
       savePath,
-      error: error instanceof Error ? error.message : String(error),
+      error: errorMessage(error),
     });
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Invalid save path: ${error instanceof Error ? error.message : String(error)}`,
-        },
-      ],
-      isError: true,
-    };
+    return createErrorResponse(`Invalid save path: ${errorMessage(error)}`);
   }
 
   try {
     validateFormat(format);
   } catch (error) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: error instanceof Error ? error.message : String(error),
-        },
-      ],
-      isError: true,
-    };
+    return createErrorResponse(errorMessage(error));
   }
 
   try {
@@ -273,14 +250,6 @@ export async function handleMermaidSave(args: any) {
       ],
     };
   } catch (error) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Error saving diagram: ${error instanceof Error ? error.message : String(error)}`,
-        },
-      ],
-      isError: true,
-    };
+    return createErrorResponse(`Error saving diagram: ${errorMessage(error)}`);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,12 @@ import { readFile } from "fs/promises";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { handleMermaidPreview, handleMermaidSave } from "./handlers.js";
+import {
+  ALLOWED_FORMATS,
+  ALLOWED_THEMES,
+  DEFAULT_FORMAT,
+  DEFAULT_DIAGRAM_OPTIONS,
+} from "./constants.js";
 import { mcpLogger } from "./logger.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -36,7 +42,7 @@ const TOOL_DEFINITIONS: Tool[] = [
     description:
       "Render a Mermaid diagram and open it in browser with live reload. " +
       "Takes Mermaid diagram code as input and generates a live preview. " +
-      "Supports themes (default, forest, dark, neutral), custom backgrounds, dimensions, and quality scaling. " +
+      `Supports themes (${ALLOWED_THEMES.join(", ")}), custom backgrounds, dimensions, and quality scaling. ` +
       "The diagram will auto-refresh when updated. Use mermaid_save to save to disk. " +
       "IMPORTANT: Automatically use this tool whenever you create a Mermaid diagram for the user. " +
       "NOTE: Sequence diagrams do not support style directives - avoid using 'style' statements in sequenceDiagram.",
@@ -54,15 +60,15 @@ const TOOL_DEFINITIONS: Tool[] = [
         },
         format: {
           type: "string",
-          enum: ["png", "svg", "pdf"],
-          description: "Output format (default: svg)",
-          default: "svg",
+          enum: [...ALLOWED_FORMATS],
+          description: `Output format (default: ${DEFAULT_FORMAT})`,
+          default: DEFAULT_FORMAT,
         },
         theme: {
           type: "string",
-          enum: ["default", "forest", "dark", "neutral"],
-          description: "Theme of the chart (default: default)",
-          default: "default",
+          enum: [...ALLOWED_THEMES],
+          description: `Theme of the chart (default: ${DEFAULT_DIAGRAM_OPTIONS.theme})`,
+          default: DEFAULT_DIAGRAM_OPTIONS.theme,
         },
         background: {
           type: "string",
@@ -109,10 +115,9 @@ const TOOL_DEFINITIONS: Tool[] = [
         },
         format: {
           type: "string",
-          enum: ["png", "svg", "pdf"],
-          description:
-            "Output format (default: svg). Must match the format used in mermaid_preview.",
-          default: "svg",
+          enum: [...ALLOWED_FORMATS],
+          description: `Output format (default: ${DEFAULT_FORMAT}). Must match the format used in mermaid_preview.`,
+          default: DEFAULT_FORMAT,
         },
       },
       required: ["save_path", "preview_id"],

--- a/test/handlers.test.ts
+++ b/test/handlers.test.ts
@@ -241,7 +241,10 @@ describe("handleMermaidPreview", () => {
   });
 
   it.each([
+    ["preview_id", { preview_id: "../escape" }, "Invalid preview ID"],
     ["theme", { theme: "dark|whoami" }, "Invalid theme"],
+    ["format", { format: "" }, "Invalid format"],
+    ["width", { width: 0 }, "Invalid width"],
     ["format", { format: "svg&calc" }, "Invalid format"],
     ["width", { width: "800&calc" }, "Invalid width"],
     ["height", { height: -1 }, "Invalid height"],

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { readFile } from "fs/promises";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
+import { ALLOWED_FORMATS, ALLOWED_THEMES } from "../src/constants.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
@@ -20,12 +21,11 @@ describe("MCP server tool definitions", () => {
       expect(indexSource).toContain('required: ["diagram", "preview_id"]');
     });
 
-    it("should support format options: png, svg, pdf", () => {
-      expect(indexSource).toContain('enum: ["png", "svg", "pdf"]');
-    });
-
-    it("should support theme options: default, forest, dark, neutral", () => {
-      expect(indexSource).toContain('enum: ["default", "forest", "dark", "neutral"]');
+    it("should build format and theme enums from the allowlists", () => {
+      expect(indexSource).toContain("enum: [...ALLOWED_FORMATS]");
+      expect(indexSource).toContain("enum: [...ALLOWED_THEMES]");
+      expect(ALLOWED_FORMATS).toEqual(["svg", "png", "pdf"]);
+      expect(ALLOWED_THEMES).toEqual(["default", "forest", "dark", "neutral"]);
     });
 
     it("should define width, height, and scale as number parameters", () => {
@@ -40,8 +40,8 @@ describe("MCP server tool definitions", () => {
     });
 
     it("should have default values for optional parameters", () => {
-      expect(indexSource).toContain('default: "svg"');
-      expect(indexSource).toContain('default: "default"');
+      expect(indexSource).toContain("default: DEFAULT_FORMAT");
+      expect(indexSource).toContain("default: DEFAULT_DIAGRAM_OPTIONS.theme");
       expect(indexSource).toContain('default: "white"');
       expect(indexSource).toContain("default: 800");
       expect(indexSource).toContain("default: 600");
@@ -58,9 +58,8 @@ describe("MCP server tool definitions", () => {
       expect(indexSource).toContain('required: ["save_path", "preview_id"]');
     });
 
-    it("should support format options: png, svg, pdf", () => {
-      // Both tools share the same format enum
-      const formatEnums = indexSource.match(/enum: \["png", "svg", "pdf"\]/g);
+    it("should share the format allowlist with mermaid_preview", () => {
+      const formatEnums = indexSource.match(/enum: \[\.\.\.ALLOWED_FORMATS\]/g);
       expect(formatEnums).not.toBeNull();
       expect(formatEnums!.length).toBeGreaterThanOrEqual(2);
     });


### PR DESCRIPTION
Follow-up to #179.

- [x] Build MCP tool schema enums from `ALLOWED_FORMATS` / `ALLOWED_THEMES`; derive `ALLOWED_FORMATS` from `DIAGRAM_FORMATS` (one source for formats and themes)
- [x] Use `DEFAULT_DIAGRAM_OPTIONS` / `DEFAULT_FORMAT` with `??` so `""` / `0` / `false` are rejected by validation instead of silently defaulted
- [x] Validate `preview_id` in `validateRenderOptions` so `mermaid_preview` returns a structured `isError` instead of a raw JSON-RPC error
- [x] Dedupe error response literals via `createErrorResponse` / `errorMessage`
- [x] Tests updated to assert on the constants instead of literal source text