### PR TITLE
fix: run bundled mermaid-cli instead of npx

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -93,10 +93,6 @@ export const CSP_HEADER =
 // ===== Validation Patterns =====
 export const PREVIEW_ID_REGEX = /^[a-zA-Z0-9_-]+$/;
 
-// CSS-color-safe allowlist. On Windows we invoke npx via `cmd.exe /c`, and
-// cmd.exe re-parses its command line with its own rules (DEP0190/CVE-2024-27980).
-// Allowing only named colors, hex, and rgb/rgba/hsl/hsla keeps shell
-// metacharacters (&, |, %, ^, <, >, ", etc.) out of the child argv.
 export const BACKGROUND_REGEX =
   /^(?:[a-zA-Z]+|#[0-9a-fA-F]{3,8}|(?:rgb|rgba|hsl|hsla)\(\s*[0-9.,%\s]+\s*\))$/;
 

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -45,12 +45,6 @@ export function validatePreviewId(previewId: string): void {
   }
 }
 
-/**
- * Validates that a background color string is safe to pass as a CLI argument.
- * Accepts CSS named colors, hex, and rgb/rgba/hsl/hsla functions — rejects
- * anything that could be interpreted as a shell metacharacter on Windows,
- * where the child process is launched via `cmd.exe /c`.
- */
 export function validateBackground(background: string): void {
   if (!background || !BACKGROUND_REGEX.test(background)) {
     throw new Error(

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -1,5 +1,6 @@
 import { execFile, spawn } from "child_process";
 import { promisify } from "util";
+import { createRequire } from "module";
 import { writeFile, mkdir, copyFile, access } from "fs/promises";
 import { join, dirname } from "path";
 import { tmpdir } from "os";
@@ -20,6 +21,10 @@ import type { RenderOptions } from "./types.js";
 import { DEFAULT_DIAGRAM_OPTIONS, DEFAULT_FORMAT } from "./constants.js";
 
 const execFileAsync = promisify(execFile);
+const mermaidCliPath = join(
+  dirname(createRequire(import.meta.url).resolve("@mermaid-js/mermaid-cli")),
+  "cli.js"
+);
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -44,8 +49,7 @@ export async function renderDiagram(options: RenderOptions, liveFilePath: string
   await writeFile(inputFile, diagram, "utf-8");
 
   const args = [
-    "-y",
-    "@mermaid-js/mermaid-cli",
+    mermaidCliPath,
     "-i",
     inputFile,
     "-o",
@@ -69,16 +73,7 @@ export async function renderDiagram(options: RenderOptions, liveFilePath: string
   mcpLogger.debug(`Executing mermaid-cli`, { args });
 
   try {
-    // On Windows, `execFile`/`spawn` cannot invoke `npx` directly: the real
-    // binary is `npx.cmd`, and Node no longer allows direct spawn of `.cmd`
-    // files (see CVE-2024-27980 / spawn EINVAL). `{ shell: true }` would work
-    // but is deprecated in Node 24+ (DEP0190) because args aren't escaped.
-    // The Node-documented pattern is to go through `cmd.exe /c` explicitly.
-    // See: https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows
-    const isWin = process.platform === "win32";
-    const command = isWin ? "cmd.exe" : "npx";
-    const finalArgs = isWin ? ["/c", "npx", ...args] : args;
-    const { stdout, stderr } = await execFileAsync(command, finalArgs);
+    const { stderr } = await execFileAsync(process.execPath, args);
     if (stderr) {
       mcpLogger.debug(`mermaid-cli stderr`, { stderr });
     }

--- a/test/handlers.test.ts
+++ b/test/handlers.test.ts
@@ -144,7 +144,7 @@ describe("handleMermaidPreview", () => {
   it("should include stderr details in error when rendering fails", async () => {
     const mockExecFile = vi.mocked(execFile);
     mockExecFile.mockImplementationOnce((_file: string, _args: any, callback: any) => {
-      const error: any = new Error("Command failed: npx mmdc");
+      const error: any = new Error("Command failed: mmdc");
       error.stderr = "Parse error on line 3: invalid syntax near 'graph'";
       callback(error, { stdout: "", stderr: error.stderr });
     });
@@ -162,7 +162,7 @@ describe("handleMermaidPreview", () => {
   it("should show original error message when stderr is empty", async () => {
     const mockExecFile = vi.mocked(execFile);
     mockExecFile.mockImplementationOnce((_file: string, _args: any, callback: any) => {
-      const error = new Error("Command failed: npx mmdc");
+      const error = new Error("Command failed: mmdc");
       callback(error, { stdout: "", stderr: "" });
     });
 
@@ -175,57 +175,22 @@ describe("handleMermaidPreview", () => {
     expect(result.content[0].text).toContain("Command failed");
   });
 
-  it("should invoke cmd.exe /c npx on win32", async () => {
-    const originalPlatform = process.platform;
-    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+  it("should run the bundled mermaid-cli with the current node binary", async () => {
     const mockExecFile = vi.mocked(execFile);
     mockExecFile.mockClear();
 
-    try {
-      await handleMermaidPreview({
-        diagram: "graph TD; A-->B",
-        preview_id: testPreviewId,
-      });
+    await handleMermaidPreview({
+      diagram: "graph TD; A-->B",
+      preview_id: testPreviewId,
+    });
 
-      expect(mockExecFile).toHaveBeenCalled();
-      const [file, args] = mockExecFile.mock.calls[0] as [string, string[], unknown];
-      expect(file).toBe("cmd.exe");
-      expect(args[0]).toBe("/c");
-      expect(args[1]).toBe("npx");
-      expect(args).toContain("@mermaid-js/mermaid-cli");
-    } finally {
-      Object.defineProperty(process, "platform", {
-        value: originalPlatform,
-        configurable: true,
-      });
-    }
+    expect(mockExecFile).toHaveBeenCalled();
+    const [file, args] = mockExecFile.mock.calls[0] as [string, string[], unknown];
+    expect(file).toBe(process.execPath);
+    expect(args[0]).toMatch(/@mermaid-js[\/\\]mermaid-cli[\/\\]src[\/\\]cli\.js$/);
   });
 
-  it("should invoke npx directly on non-win32 platforms", async () => {
-    const originalPlatform = process.platform;
-    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
-    const mockExecFile = vi.mocked(execFile);
-    mockExecFile.mockClear();
-
-    try {
-      await handleMermaidPreview({
-        diagram: "graph TD; A-->B",
-        preview_id: testPreviewId,
-      });
-
-      expect(mockExecFile).toHaveBeenCalled();
-      const [file, args] = mockExecFile.mock.calls[0] as [string, string[], unknown];
-      expect(file).toBe("npx");
-      expect(args[0]).not.toBe("/c");
-    } finally {
-      Object.defineProperty(process, "platform", {
-        value: originalPlatform,
-        configurable: true,
-      });
-    }
-  });
-
-  it("should reject background with shell metacharacters without invoking npx", async () => {
+  it("should reject background with shell metacharacters without invoking mermaid-cli", async () => {
     const mockExecFile = vi.mocked(execFile);
     mockExecFile.mockClear();
 
@@ -249,20 +214,23 @@ describe("handleMermaidPreview", () => {
     ["width", { width: "800&calc" }, "Invalid width"],
     ["height", { height: -1 }, "Invalid height"],
     ["scale", { scale: Infinity }, "Invalid scale"],
-  ])("should reject invalid %s without invoking npx", async (_label, overrides, message) => {
-    const mockExecFile = vi.mocked(execFile);
-    mockExecFile.mockClear();
+  ])(
+    "should reject invalid %s without invoking mermaid-cli",
+    async (_label, overrides, message) => {
+      const mockExecFile = vi.mocked(execFile);
+      mockExecFile.mockClear();
 
-    const result = await handleMermaidPreview({
-      diagram: "graph TD; A-->B",
-      preview_id: testPreviewId,
-      ...overrides,
-    });
+      const result = await handleMermaidPreview({
+        diagram: "graph TD; A-->B",
+        preview_id: testPreviewId,
+        ...overrides,
+      });
 
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain(message);
-    expect(mockExecFile).not.toHaveBeenCalled();
-  });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain(message);
+      expect(mockExecFile).not.toHaveBeenCalled();
+    }
+  );
 });
 
 describe("handleMermaidSave", () => {
@@ -333,7 +301,7 @@ describe("handleMermaidSave", () => {
     await unlink(pngPath);
   });
 
-  it("should reject invalid format without invoking npx", async () => {
+  it("should reject invalid format without invoking mermaid-cli", async () => {
     const mockExecFile = vi.mocked(execFile);
     mockExecFile.mockClear();
 


### PR DESCRIPTION
## Overview

- [x] run the installed `@mermaid-js/mermaid-cli` `cli.js` with `process.execPath` instead of `npx -y @mermaid-js/mermaid-cli`, so renders use the lockfile version rather than the registry's `latest`
- [x] drop the Windows `cmd.exe /c` special case (only needed because `npx` is a `.cmd` there) and its now-stale comments