### PR TITLE
feat: add artifact preview backend

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-mermaid",
   "description": "MCP server for previewing Mermaid diagrams in Claude Code",
-  "version": "1.2.0",
+  "version": "1.6.5",
   "author": {
     "name": "Vitalii Elenhaupt",
     "url": "https://github.com/veelenga"
@@ -11,7 +11,10 @@
   "mcpServers": {
     "mermaid": {
       "command": "npx",
-      "args": ["-y", "claude-mermaid"]
+      "args": ["-y", "claude-mermaid"],
+      "env": {
+        "CLAUDE_MERMAID_PREVIEW": "${CLAUDE_MERMAID_PREVIEW:-live}"
+      }
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "mermaid": {
       "command": "npx",
-      "args": ["-y", "claude-mermaid"]
+      "args": ["-y", "claude-mermaid"],
+      "env": {
+        "CLAUDE_MERMAID_PREVIEW": "${CLAUDE_MERMAID_PREVIEW:-live}"
+      }
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Artifact preview backend: run with `--preview artifact` or `CLAUDE_MERMAID_PREVIEW=artifact` to have `mermaid_preview` write a self-contained HTML page for publishing as a Claude artifact instead of starting the local live server
+- Copy SVG button in the diagram viewer toolbar
+
+### Changed
+
+- Split the preview page script into a shared viewer (pan, zoom, copy) and live-server-only features (websocket reload, export, editor links)
+
 ### Security
 
 - Validate theme, format, width, height and scale before rendering to prevent command injection via `cmd.exe /c` on Windows; re-render paths (`mermaid_save`, `/export/`) are validated too

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Artifact preview backend: run with `--preview artifact` or `CLAUDE_MERMAID_PREVIEW=artifact` to have `mermaid_preview` write a self-contained HTML page for publishing as a Claude artifact instead of starting the local live server
 - Copy SVG button in the diagram viewer toolbar
+- Plugin and example MCP configs forward `CLAUDE_MERMAID_PREVIEW` from the shell so plugin installs can enable artifact mode
 
 ### Changed
 
+- CLI flags are parsed with `util.parseArgs`; unknown flags and a missing `--preview` value now fail fast with a clear error
 - Split the preview page script into a shared viewer (pan, zoom, copy) and live-server-only features (websocket reload, export, editor links)
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -373,6 +373,12 @@ In artifact mode:
 - The page includes pan, zoom and copy-SVG controls and has no external dependencies.
 - No local server is started and no browser tab is opened. `mermaid_save` works unchanged.
 
+**Plugin installs:** the plugin forwards the `CLAUDE_MERMAID_PREVIEW` variable from your shell, so export it before starting Claude Code:
+
+```bash
+export CLAUDE_MERMAID_PREVIEW=artifact
+```
+
 Artifact mode requires a host with the Artifact tool, such as Claude Code. Other MCP clients should keep the default `live` backend.
 
 ## 🖥️ Standalone server

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Automatically renders diagrams in your browser with real-time updates as you ref
 ## ✨ Features
 
 - 🔄 **Live Reload** - Diagrams auto-refresh in your browser as you edit
+- 🪄 **Artifact Mode** - Optionally publish diagrams as shareable Claude artifacts instead of running a local server
 - 🎨 **Multiple Save Formats** - Export to SVG, PNG, or PDF
 - 🌈 **Themes** - Choose from default, forest, dark, or neutral themes
 - 📐 **Customizable** - Control dimensions, scale, and background colors
@@ -335,6 +336,44 @@ The live server uses ports 3737-3747 and automatically finds an available port.
 
 - Live preview is available for `svg` format only; PNG/PDF are rendered without live reload.
 - For sequence diagrams, Mermaid does not support `style` directives inside `sequenceDiagram`.
+
+## 🪄 Artifact mode
+
+By default, previews are served by a local HTTP server with live reload. In Claude Code you can instead have `mermaid_preview` produce a self-contained HTML page that Claude publishes as a [Claude artifact](https://claude.ai/code/artifacts). Artifacts are easy to share and update in place: republishing the same page updates the existing URL.
+
+Enable it with a CLI flag or an environment variable in your MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "mermaid": {
+      "command": "npx",
+      "args": ["-y", "claude-mermaid", "--preview", "artifact"]
+    }
+  }
+}
+```
+
+```json
+{
+  "mcpServers": {
+    "mermaid": {
+      "command": "npx",
+      "args": ["-y", "claude-mermaid"],
+      "env": { "CLAUDE_MERMAID_PREVIEW": "artifact" }
+    }
+  }
+}
+```
+
+In artifact mode:
+
+- `mermaid_preview` renders and validates the diagram with mermaid-cli as usual, then writes `artifact.html` next to the working files under `~/.config/claude-mermaid/live/{preview_id}/`.
+- The tool response tells Claude to publish that page with the Artifact tool and to republish the same path after every update, so the artifact URL stays stable per `preview_id`.
+- The page includes pan, zoom and copy-SVG controls and has no external dependencies.
+- No local server is started and no browser tab is opened. `mermaid_save` works unchanged.
+
+Artifact mode requires a host with the Artifact tool, such as Claude Code. Other MCP clients should keep the default `live` backend.
 
 ## 🖥️ Standalone server
 

--- a/skills/mermaid-diagrams/SKILL.md
+++ b/skills/mermaid-diagrams/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mermaid-diagrams
-description: Creating and refining Mermaid diagrams with live reload. Use when users want flowcharts, sequence diagrams, class diagrams, ER diagrams, state diagrams, or any other Mermaid visualization. Provides best practices for syntax, styling, and the iterative workflow using mermaid_preview and mermaid_save tools.
-allowed-tools: mcp__mermaid__mermaid_preview, mcp__mermaid__mermaid_save
+description: Creating and refining Mermaid diagrams with live reload or as shareable Claude artifacts. Use when users want flowcharts, sequence diagrams, class diagrams, ER diagrams, state diagrams, or any other Mermaid visualization. Provides best practices for syntax, styling, and the iterative workflow using mermaid_preview and mermaid_save tools.
+allowed-tools: mcp__mermaid__mermaid_preview, mcp__mermaid__mermaid_save, Artifact
 ---
 
 # Mermaid Diagram Expert

--- a/skills/mermaid-diagrams/SKILL.md
+++ b/skills/mermaid-diagrams/SKILL.md
@@ -41,6 +41,15 @@ Use after the diagram is finalized:
 - `preview_id`: Must match the preview ID used earlier
 - `format`: Must match format from preview
 
+### Artifact mode
+
+When the server runs with the artifact preview backend, `mermaid_preview` does not open a browser. Instead its response contains an `Artifact page:` path.
+
+- Publish that path with the Artifact tool right away, using the 📊 favicon on the first publish
+- After every refinement, call `mermaid_preview` with the same `preview_id`, then republish the same path so the existing artifact URL is updated in place
+- Never publish a different path for the same diagram; that would create a new artifact
+- Share the artifact URL with the user once, and mention that later updates appear at the same URL
+
 ## Diagram Types
 
 ### Flowcharts (`graph` or `flowchart`)
@@ -203,7 +212,7 @@ When a user requests a diagram:
 **User**: "Add database and error handling"
 
 **You**: "I'll add database interaction and error paths."
-[Use mermaid_preview with same preview_id - browser auto-refreshes]
+[Use mermaid_preview with same preview_id - browser auto-refreshes, or republish the artifact page in artifact mode]
 
 **User**: "Save it"
 

--- a/src/artifact-preview-backend.ts
+++ b/src/artifact-preview-backend.ts
@@ -1,0 +1,78 @@
+import { readFile, writeFile } from "fs/promises";
+import { getArtifactPagePath } from "./file-utils.js";
+import { loadTemplate, escapeHtml } from "./page-renderer.js";
+import { mcpLogger } from "./logger.js";
+import {
+  ARTIFACT_FAVICON,
+  ASSET_FILES,
+  PREVIEW_BACKENDS,
+  TEMPLATE_FILES,
+  TEMPLATE_VARS,
+} from "./constants.js";
+import type { PreviewBackend, PreviewRequest } from "./types.js";
+
+export function toPageTitle(previewId: string): string {
+  const words = previewId.replace(/[-_]+/g, " ").trim();
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+function fill(template: string, placeholder: string, value: string): string {
+  return template.replaceAll(placeholder, () => value);
+}
+
+function wrapInTag(tag: string, content: string): string {
+  return `<${tag}>\n${content}\n</${tag}>`;
+}
+
+export async function buildArtifactPage(
+  previewId: string,
+  svg: string,
+  background: string
+): Promise<string> {
+  const [template, styles, script] = await Promise.all([
+    loadTemplate(TEMPLATE_FILES.ARTIFACT),
+    loadTemplate(ASSET_FILES.STYLE),
+    loadTemplate(ASSET_FILES.VIEWER_SCRIPT),
+  ]);
+
+  const replacements: Array<[string, string]> = [
+    [TEMPLATE_VARS.TITLE, escapeHtml(toPageTitle(previewId))],
+    [TEMPLATE_VARS.STYLES, wrapInTag("style", styles)],
+    [TEMPLATE_VARS.SCRIPT, wrapInTag("script", script)],
+    [TEMPLATE_VARS.CONTENT, svg],
+    [TEMPLATE_VARS.DIAGRAM_ID, escapeHtml(previewId)],
+    [TEMPLATE_VARS.BACKGROUND, escapeHtml(background)],
+    [TEMPLATE_VARS.TIMESTAMP, escapeHtml(new Date().toLocaleTimeString())],
+  ];
+
+  return replacements.reduce(
+    (page, [placeholder, value]) => fill(page, placeholder, value),
+    template
+  );
+}
+
+export class ArtifactPreviewBackend implements PreviewBackend {
+  readonly name = PREVIEW_BACKENDS.ARTIFACT;
+
+  readonly toolDescription =
+    "Render a Mermaid diagram into a self-contained HTML page ready to publish as a Claude artifact. " +
+    "Takes Mermaid diagram code as input, validates it, and writes a page with pan and zoom controls. " +
+    "Publish the returned artifact page path with the Artifact tool, and republish the same path after every update.";
+
+  async present({ previewId, filePath, format, background }: PreviewRequest): Promise<string> {
+    const svg = await readFile(filePath, "utf-8");
+    const page = await buildArtifactPage(previewId, svg, background);
+    const pagePath = getArtifactPagePath(previewId);
+    await writeFile(pagePath, page, "utf-8");
+
+    mcpLogger.info(`Artifact page written: ${previewId}`, { pagePath });
+
+    return (
+      `Mermaid diagram rendered successfully.\n` +
+      `Working file: ${filePath} (${format.toUpperCase()})\n` +
+      `Artifact page: ${pagePath}\n\n` +
+      `Publish the artifact page with the Artifact tool to show it to the user (suggested favicon: ${ARTIFACT_FAVICON}). ` +
+      `Always republish this same path after updating preview "${previewId}" so the existing artifact URL is updated in place.`
+    );
+  }
+}

--- a/src/artifact-preview-backend.ts
+++ b/src/artifact-preview-backend.ts
@@ -1,27 +1,13 @@
 import { readFile, writeFile } from "fs/promises";
 import { getArtifactPagePath } from "./file-utils.js";
-import { loadTemplate, escapeHtml } from "./page-renderer.js";
+import { loadTemplate, fillTemplate, diagramPageData, escapeHtml } from "./page-renderer.js";
 import { mcpLogger } from "./logger.js";
-import {
-  ARTIFACT_FAVICON,
-  ASSET_FILES,
-  PREVIEW_BACKENDS,
-  TEMPLATE_FILES,
-  TEMPLATE_VARS,
-} from "./constants.js";
+import { ASSET_FILES, TEMPLATE_FILES } from "./constants.js";
 import type { PreviewBackend, PreviewRequest } from "./types.js";
 
 export function toPageTitle(previewId: string): string {
   const words = previewId.replace(/[-_]+/g, " ").trim();
   return words.charAt(0).toUpperCase() + words.slice(1);
-}
-
-function fill(template: string, placeholder: string, value: string): string {
-  return template.replaceAll(placeholder, () => value);
-}
-
-function wrapInTag(tag: string, content: string): string {
-  return `<${tag}>\n${content}\n</${tag}>`;
 }
 
 export async function buildArtifactPage(
@@ -35,31 +21,21 @@ export async function buildArtifactPage(
     loadTemplate(ASSET_FILES.VIEWER_SCRIPT),
   ]);
 
-  const replacements: Array<[string, string]> = [
-    [TEMPLATE_VARS.TITLE, escapeHtml(toPageTitle(previewId))],
-    [TEMPLATE_VARS.STYLES, wrapInTag("style", styles)],
-    [TEMPLATE_VARS.SCRIPT, wrapInTag("script", script)],
-    [TEMPLATE_VARS.CONTENT, svg],
-    [TEMPLATE_VARS.DIAGRAM_ID, escapeHtml(previewId)],
-    [TEMPLATE_VARS.BACKGROUND, escapeHtml(background)],
-    [TEMPLATE_VARS.TIMESTAMP, escapeHtml(new Date().toLocaleTimeString())],
-  ];
-
-  return replacements.reduce(
-    (page, [placeholder, value]) => fill(page, placeholder, value),
-    template
-  );
+  return fillTemplate(template, {
+    PAGE_TITLE: escapeHtml(toPageTitle(previewId)),
+    PAGE_STYLES: `<style>\n${styles}\n</style>`,
+    PAGE_SCRIPTS: `<script>\n${script}\n</script>`,
+    ...diagramPageData(previewId, svg, background),
+  });
 }
 
 export class ArtifactPreviewBackend implements PreviewBackend {
-  readonly name = PREVIEW_BACKENDS.ARTIFACT;
-
   readonly toolDescription =
     "Render a Mermaid diagram into a self-contained HTML page ready to publish as a Claude artifact. " +
     "Takes Mermaid diagram code as input, validates it, and writes a page with pan and zoom controls. " +
     "Publish the returned artifact page path with the Artifact tool, and republish the same path after every update.";
 
-  async present({ previewId, filePath, format, background }: PreviewRequest): Promise<string> {
+  async present({ previewId, filePath, background }: PreviewRequest): Promise<string> {
     const svg = await readFile(filePath, "utf-8");
     const page = await buildArtifactPage(previewId, svg, background);
     const pagePath = getArtifactPagePath(previewId);
@@ -69,9 +45,9 @@ export class ArtifactPreviewBackend implements PreviewBackend {
 
     return (
       `Mermaid diagram rendered successfully.\n` +
-      `Working file: ${filePath} (${format.toUpperCase()})\n` +
+      `Working file: ${filePath} (SVG)\n` +
       `Artifact page: ${pagePath}\n\n` +
-      `Publish the artifact page with the Artifact tool to show it to the user (suggested favicon: ${ARTIFACT_FAVICON}). ` +
+      `Publish the artifact page with the Artifact tool to show it to the user (suggested favicon: 📊). ` +
       `Always republish this same path after updating preview "${previewId}" so the existing artifact URL is updated in place.`
     );
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,19 @@
+import { parseArgs } from "util";
+
+export interface CliOptions {
+  version: boolean;
+  serve: boolean;
+  preview?: string;
+}
+
+export function parseCliOptions(args: string[] = process.argv.slice(2)): CliOptions {
+  const { values } = parseArgs({
+    args,
+    options: {
+      version: { type: "boolean", short: "v", default: false },
+      serve: { type: "boolean", default: false },
+      preview: { type: "string" },
+    },
+  });
+  return { version: values.version, serve: values.serve, preview: values.preview };
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,7 +36,7 @@ export const TEMPLATE_FILES = {
   LAYOUT: "layout.html",
   GALLERY: "gallery.html",
   DIAGRAM: "template.html",
-  ARTIFACT: "artifact.html",
+  ARTIFACT: "artifact-template.html",
 } as const;
 
 // ===== Static Asset Files =====
@@ -123,24 +123,6 @@ export const WS_MESSAGES = {
   RELOAD: "reload",
 } as const;
 
-// ===== Template Placeholders =====
-export const TEMPLATE_VARS = {
-  CONTENT: "{{CONTENT}}",
-  NAV: "{{NAV}}",
-  FOOTER: "{{FOOTER}}",
-  DIAGRAM_ID: "{{DIAGRAM_ID}}",
-  PORT: "{{PORT}}",
-  BACKGROUND: "{{BACKGROUND}}",
-  TIMESTAMP: "{{TIMESTAMP}}",
-  LIVE_ENABLED: "{{LIVE_ENABLED}}",
-  PAGE_TITLE: "{{PAGE_TITLE}}",
-  PAGE_SCRIPTS: "{{PAGE_SCRIPTS}}",
-  PAGE_STYLES: "{{PAGE_STYLES}}",
-  TITLE: "{{TITLE}}",
-  STYLES: "{{STYLES}}",
-  SCRIPT: "{{SCRIPT}}",
-} as const;
-
 // ===== Diagram Options Defaults =====
 export const DEFAULT_DIAGRAM_OPTIONS = {
   theme: "default",
@@ -176,4 +158,3 @@ export const ALLOWED_PREVIEW_BACKENDS: readonly PreviewBackendName[] =
   Object.values(PREVIEW_BACKENDS);
 export const PREVIEW_BACKEND_ENV_VAR = "CLAUDE_MERMAID_PREVIEW";
 export const PREVIEW_BACKEND_FLAG = "--preview";
-export const ARTIFACT_FAVICON = "📊";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,7 @@ export const FILE_NAMES = {
   DIAGRAM_SVG: "diagram.svg",
   DIAGRAM_PNG: "diagram.png",
   DIAGRAM_PDF: "diagram.pdf",
+  ARTIFACT_PAGE: "artifact.html",
 } as const;
 
 // ===== Directory Names =====
@@ -35,6 +36,7 @@ export const TEMPLATE_FILES = {
   LAYOUT: "layout.html",
   GALLERY: "gallery.html",
   DIAGRAM: "template.html",
+  ARTIFACT: "artifact.html",
 } as const;
 
 // ===== Static Asset Files =====
@@ -43,9 +45,9 @@ export const ASSET_FILES = {
   SHARED_STYLE: "shared.css",
   GALLERY_STYLE: "gallery.css",
   SCRIPT: "script.js",
+  VIEWER_SCRIPT: "viewer.js",
   GALLERY_SCRIPT: "gallery.js",
   FAVICON: "favicon.svg",
-  VIEWER_SCRIPT: "viewer.js",
 } as const;
 
 // ===== HTTP Routes =====
@@ -63,9 +65,9 @@ export const ROUTES = {
   SHARED_STYLE: "/shared.css",
   GALLERY_STYLE: "/gallery.css",
   SCRIPT: "/script.js",
+  VIEWER_SCRIPT: "/viewer.js",
   GALLERY_SCRIPT: "/gallery.js",
 } as const;
-  VIEWER_SCRIPT: "/viewer.js",
 
 // ===== HTTP Headers =====
 export const CONTENT_TYPES = {
@@ -134,6 +136,9 @@ export const TEMPLATE_VARS = {
   PAGE_TITLE: "{{PAGE_TITLE}}",
   PAGE_SCRIPTS: "{{PAGE_SCRIPTS}}",
   PAGE_STYLES: "{{PAGE_STYLES}}",
+  TITLE: "{{TITLE}}",
+  STYLES: "{{STYLES}}",
+  SCRIPT: "{{SCRIPT}}",
 } as const;
 
 // ===== Diagram Options Defaults =====
@@ -157,3 +162,18 @@ export type DiagramFormat = (typeof DIAGRAM_FORMATS)[keyof typeof DIAGRAM_FORMAT
 export const DEFAULT_FORMAT: DiagramFormat = DIAGRAM_FORMATS.SVG;
 export const ALLOWED_FORMATS: readonly DiagramFormat[] = Object.values(DIAGRAM_FORMATS);
 export const ALLOWED_THEMES = ["default", "forest", "dark", "neutral"] as const;
+
+// ===== Preview Backends =====
+export const PREVIEW_BACKENDS = {
+  LIVE: "live",
+  ARTIFACT: "artifact",
+} as const;
+
+export type PreviewBackendName = (typeof PREVIEW_BACKENDS)[keyof typeof PREVIEW_BACKENDS];
+
+export const DEFAULT_PREVIEW_BACKEND: PreviewBackendName = PREVIEW_BACKENDS.LIVE;
+export const ALLOWED_PREVIEW_BACKENDS: readonly PreviewBackendName[] =
+  Object.values(PREVIEW_BACKENDS);
+export const PREVIEW_BACKEND_ENV_VAR = "CLAUDE_MERMAID_PREVIEW";
+export const PREVIEW_BACKEND_FLAG = "--preview";
+export const ARTIFACT_FAVICON = "📊";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,6 +45,7 @@ export const ASSET_FILES = {
   SCRIPT: "script.js",
   GALLERY_SCRIPT: "gallery.js",
   FAVICON: "favicon.svg",
+  VIEWER_SCRIPT: "viewer.js",
 } as const;
 
 // ===== HTTP Routes =====
@@ -64,6 +65,7 @@ export const ROUTES = {
   SCRIPT: "/script.js",
   GALLERY_SCRIPT: "/gallery.js",
 } as const;
+  VIEWER_SCRIPT: "/viewer.js",
 
 // ===== HTTP Headers =====
 export const CONTENT_TYPES = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -157,4 +157,3 @@ export const DEFAULT_PREVIEW_BACKEND: PreviewBackendName = PREVIEW_BACKENDS.LIVE
 export const ALLOWED_PREVIEW_BACKENDS: readonly PreviewBackendName[] =
   Object.values(PREVIEW_BACKENDS);
 export const PREVIEW_BACKEND_ENV_VAR = "CLAUDE_MERMAID_PREVIEW";
-export const PREVIEW_BACKEND_FLAG = "--preview";

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -106,6 +106,10 @@ export function getDiagramOptionsPath(previewId: string): string {
   return join(getPreviewDir(previewId), FILE_NAMES.DIAGRAM_OPTIONS);
 }
 
+export function getArtifactPagePath(previewId: string): string {
+  return join(getPreviewDir(previewId), FILE_NAMES.ARTIFACT_PAGE);
+}
+
 // Re-export DiagramOptions type from types.ts for backward compatibility
 export type { DiagramOptions } from "./types.js";
 

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -11,6 +11,8 @@ import {
   DIR_NAMES,
   ALLOWED_THEMES,
   ALLOWED_FORMATS,
+  ALLOWED_PREVIEW_BACKENDS,
+  type PreviewBackendName,
 } from "./constants.js";
 import type { DiagramOptions, RenderOptions } from "./types.js";
 
@@ -71,6 +73,10 @@ export function validateTheme(theme: string): void {
 
 export function validateFormat(format: string): void {
   validateAllowed("format", format, ALLOWED_FORMATS);
+}
+
+export function validatePreviewBackend(name: string): asserts name is PreviewBackendName {
+  validateAllowed("preview backend", name, ALLOWED_PREVIEW_BACKENDS);
 }
 
 export function validateDimension(label: string, value: number): void {

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -14,7 +14,6 @@ import {
   validateRenderOptions,
 } from "./file-utils.js";
 import { mcpLogger } from "./logger.js";
-import { createPreviewBackend } from "./preview-backend.js";
 import type { PreviewBackend, RenderOptions } from "./types.js";
 import { DEFAULT_DIAGRAM_OPTIONS, DEFAULT_FORMAT, DIAGRAM_FORMATS } from "./constants.js";
 
@@ -97,16 +96,13 @@ function createStaticRenderResponse(liveFilePath: string, format: string): any {
     content: [
       {
         type: "text",
-        text: `Mermaid diagram rendered successfully.\nWorking file: ${liveFilePath} (${format.toUpperCase()})\n\nNote: Live preview is only available for SVG format. Use mermaid_save to save this diagram to a permanent location.`,
+        text: `Mermaid diagram rendered successfully.\nWorking file: ${liveFilePath} (${format.toUpperCase()})\n\nNote: Preview is only available for SVG format. Use mermaid_save to save this diagram to a permanent location.`,
       },
     ],
   };
 }
 
-export async function handleMermaidPreview(
-  args: any,
-  previewBackend: PreviewBackend = createPreviewBackend()
-) {
+export async function handleMermaidPreview(args: any, previewBackend: PreviewBackend) {
   const diagram = args.diagram as string;
   const previewId = args.preview_id as string;
   const format = (args.format as string) ?? DEFAULT_FORMAT;
@@ -143,12 +139,7 @@ export async function handleMermaidPreview(
       return createStaticRenderResponse(liveFilePath, format);
     }
 
-    const text = await previewBackend.present({
-      previewId,
-      filePath: liveFilePath,
-      format,
-      background,
-    });
+    const text = await previewBackend.present({ previewId, filePath: liveFilePath, background });
     return { content: [{ type: "text", text }] };
   } catch (error) {
     return createErrorResponse(`Error rendering Mermaid diagram: ${errorMessage(error)}`);

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -1,9 +1,8 @@
-import { execFile, spawn } from "child_process";
+import { execFile } from "child_process";
 import { promisify } from "util";
 import { writeFile, mkdir, copyFile, access } from "fs/promises";
 import { join, dirname } from "path";
 import { tmpdir } from "os";
-import { ensureLiveServer, addLiveDiagram, hasActiveConnections } from "./live-server.js";
 import {
   getDiagramFilePath,
   getPreviewDir,
@@ -13,11 +12,11 @@ import {
   validateSavePath,
   validateFormat,
   validateRenderOptions,
-  getOpenCommand,
 } from "./file-utils.js";
 import { mcpLogger } from "./logger.js";
-import type { RenderOptions } from "./types.js";
-import { DEFAULT_DIAGRAM_OPTIONS, DEFAULT_FORMAT } from "./constants.js";
+import { createPreviewBackend } from "./preview-backend.js";
+import type { PreviewBackend, RenderOptions } from "./types.js";
+import { DEFAULT_DIAGRAM_OPTIONS, DEFAULT_FORMAT, DIAGRAM_FORMATS } from "./constants.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -93,55 +92,6 @@ export async function renderDiagram(options: RenderOptions, liveFilePath: string
   }
 }
 
-async function setupLivePreview(
-  previewId: string,
-  liveFilePath: string
-): Promise<{ serverUrl: string; hasConnections: boolean }> {
-  const port = await ensureLiveServer();
-  const hasConnections = hasActiveConnections(previewId);
-
-  await addLiveDiagram(previewId, liveFilePath);
-  const serverUrl = `http://localhost:${port}/${previewId}`;
-
-  if (!hasConnections) {
-    mcpLogger.info(`Opening browser for new diagram: ${previewId}`, { serverUrl });
-    const { command, args } = getOpenCommand(serverUrl);
-    const child = spawn(command, args, { detached: true, stdio: "ignore" });
-    child.on("error", (error) => {
-      mcpLogger.warn("Failed to open browser", { error: error.message, serverUrl });
-    });
-    child.unref();
-  } else {
-    mcpLogger.info(`Reusing existing browser tab for diagram: ${previewId}`);
-  }
-
-  return { serverUrl, hasConnections };
-}
-
-function createLivePreviewResponse(
-  liveFilePath: string,
-  format: string,
-  serverUrl: string,
-  hasConnections: boolean
-): any {
-  const actionMessage = hasConnections
-    ? `Mermaid diagram updated successfully.`
-    : `Mermaid diagram rendered successfully and opened in browser.`;
-
-  const liveMessage = hasConnections
-    ? `\nDiagram updated. Browser will refresh automatically.`
-    : `\nLive reload URL: ${serverUrl}\nThe diagram will auto-refresh when you update it.`;
-
-  return {
-    content: [
-      {
-        type: "text",
-        text: `${actionMessage}\nWorking file: ${liveFilePath} (${format.toUpperCase()})${liveMessage}`,
-      },
-    ],
-  };
-}
-
 function createStaticRenderResponse(liveFilePath: string, format: string): any {
   return {
     content: [
@@ -153,7 +103,10 @@ function createStaticRenderResponse(liveFilePath: string, format: string): any {
   };
 }
 
-export async function handleMermaidPreview(args: any) {
+export async function handleMermaidPreview(
+  args: any,
+  previewBackend: PreviewBackend = createPreviewBackend()
+) {
   const diagram = args.diagram as string;
   const previewId = args.preview_id as string;
   const format = (args.format as string) ?? DEFAULT_FORMAT;
@@ -186,12 +139,17 @@ export async function handleMermaidPreview(args: any) {
     await saveDiagramSource(previewId, diagram, { theme, background, width, height, scale });
     await renderDiagram(renderOptions, liveFilePath);
 
-    if (format === "svg") {
-      const { serverUrl, hasConnections } = await setupLivePreview(previewId, liveFilePath);
-      return createLivePreviewResponse(liveFilePath, format, serverUrl, hasConnections);
-    } else {
+    if (format !== DIAGRAM_FORMATS.SVG) {
       return createStaticRenderResponse(liveFilePath, format);
     }
+
+    const text = await previewBackend.present({
+      previewId,
+      filePath: liveFilePath,
+      format,
+      background,
+    });
+    return { content: [{ type: "text", text }] };
   } catch (error) {
     return createErrorResponse(`Error rendering Mermaid diagram: ${errorMessage(error)}`);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,193 +2,100 @@
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-  Tool,
-} from "@modelcontextprotocol/sdk/types.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { readFile } from "fs/promises";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { handleMermaidPreview, handleMermaidSave } from "./handlers.js";
-import {
-  ALLOWED_FORMATS,
-  ALLOWED_THEMES,
-  DEFAULT_FORMAT,
-  DEFAULT_DIAGRAM_OPTIONS,
-} from "./constants.js";
+import { buildToolDefinitions } from "./tool-definitions.js";
+import { parseCliOptions } from "./cli.js";
+import { createPreviewBackend, resolvePreviewBackendName } from "./preview-backend.js";
 import { mcpLogger } from "./logger.js";
-import { createPreviewBackend } from "./preview-backend.js";
+import type { PreviewBackend } from "./types.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const packageJson = JSON.parse(await readFile(join(__dirname, "../package.json"), "utf-8"));
 const VERSION = packageJson.version;
 
-if (process.argv.includes("-v") || process.argv.includes("--version")) {
-  console.log(VERSION);
-  process.exit(0);
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
-const isServeMode = process.argv.includes("--serve");
+function createMcpServer(previewBackend: PreviewBackend): Server {
+  const server = new Server(
+    { name: "claude-mermaid", version: VERSION },
+    { capabilities: { tools: {} } }
+  );
+  const tools = buildToolDefinitions(previewBackend);
 
-if (isServeMode) {
-  const { startServeMode } = await import("./serve.js");
-  await startServeMode();
-}
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    mcpLogger.debug("ListTools request received");
+    return { tools };
+  });
 
-const previewBackend = createPreviewBackend();
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const toolName = request.params.name;
+    const args = request.params.arguments;
 
-const TOOL_DEFINITIONS: Tool[] = [
-  {
-    name: "mermaid_preview",
-    description:
-      `${previewBackend.toolDescription} ` +
-      `Supports themes (${ALLOWED_THEMES.join(", ")}), custom backgrounds, dimensions, and quality scaling. ` +
-      "Use mermaid_save to save to disk. " +
-      "IMPORTANT: Automatically use this tool whenever you create a Mermaid diagram for the user. " +
-      "NOTE: Sequence diagrams do not support style directives - avoid using 'style' statements in sequenceDiagram.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        diagram: {
-          type: "string",
-          description: "The Mermaid diagram code to render",
-        },
-        preview_id: {
-          type: "string",
-          description:
-            "ID for this preview session. Use different IDs for multiple diagrams (e.g., 'architecture', 'flow', 'sequence').",
-        },
-        format: {
-          type: "string",
-          enum: [...ALLOWED_FORMATS],
-          description: `Output format (default: ${DEFAULT_FORMAT})`,
-          default: DEFAULT_FORMAT,
-        },
-        theme: {
-          type: "string",
-          enum: [...ALLOWED_THEMES],
-          description: `Theme of the chart (default: ${DEFAULT_DIAGRAM_OPTIONS.theme})`,
-          default: DEFAULT_DIAGRAM_OPTIONS.theme,
-        },
-        background: {
-          type: "string",
-          description:
-            "Background color for pngs/svgs. Example: transparent, red, '#F0F0F0' (default: white)",
-          default: "white",
-        },
-        width: {
-          type: "number",
-          description: "Diagram width in pixels (default: 800)",
-          default: 800,
-        },
-        height: {
-          type: "number",
-          description: "Diagram height in pixels (default: 600)",
-          default: 600,
-        },
-        scale: {
-          type: "number",
-          description: "Scale factor for higher quality output (default: 2)",
-          default: 2,
-        },
-      },
-      required: ["diagram", "preview_id"],
-    },
-  },
-  {
-    name: "mermaid_save",
-    description:
-      "Save the current live Mermaid diagram to a file path. " +
-      "This copies the already-rendered diagram from the live preview to the specified location. " +
-      "Use this after tuning your diagram with mermaid_preview.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        save_path: {
-          type: "string",
-          description: "Path to save the diagram file (e.g., './docs/diagram.svg')",
-        },
-        preview_id: {
-          type: "string",
-          description:
-            "ID of the preview to save. Must match the preview_id used in mermaid_preview.",
-        },
-        format: {
-          type: "string",
-          enum: [...ALLOWED_FORMATS],
-          description: `Output format (default: ${DEFAULT_FORMAT}). Must match the format used in mermaid_preview.`,
-          default: DEFAULT_FORMAT,
-        },
-      },
-      required: ["save_path", "preview_id"],
-    },
-  },
-];
+    mcpLogger.info(`CallTool request: ${toolName}`);
 
-const server = new Server(
-  {
-    name: "claude-mermaid",
-    version: VERSION,
-  },
-  {
-    capabilities: {
-      tools: {},
-    },
-  }
-);
-
-server.setRequestHandler(ListToolsRequestSchema, async () => {
-  mcpLogger.debug("ListTools request received");
-  return { tools: TOOL_DEFINITIONS };
-});
-
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const toolName = request.params.name;
-  const args = request.params.arguments;
-
-  mcpLogger.info(`CallTool request: ${toolName}`);
-
-  try {
-    let result;
-    switch (toolName) {
-      case "mermaid_preview":
-        result = await handleMermaidPreview(args, previewBackend);
-        mcpLogger.info(`CallTool completed: ${toolName}`);
-        return result;
-      case "mermaid_save":
-        result = await handleMermaidSave(args);
-        mcpLogger.info(`CallTool completed: ${toolName}`);
-        return result;
-      default:
-        mcpLogger.error(`Unknown tool: ${toolName}`);
-        throw new Error(`Unknown tool: ${toolName}`);
+    try {
+      let result;
+      switch (toolName) {
+        case "mermaid_preview":
+          result = await handleMermaidPreview(args, previewBackend);
+          mcpLogger.info(`CallTool completed: ${toolName}`);
+          return result;
+        case "mermaid_save":
+          result = await handleMermaidSave(args);
+          mcpLogger.info(`CallTool completed: ${toolName}`);
+          return result;
+        default:
+          mcpLogger.error(`Unknown tool: ${toolName}`);
+          throw new Error(`Unknown tool: ${toolName}`);
+      }
+    } catch (error) {
+      mcpLogger.error(`Tool ${toolName} failed`, { error: errorMessage(error) });
+      throw error;
     }
-  } catch (error) {
-    mcpLogger.error(`Tool ${toolName} failed`, {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    throw error;
-  }
-});
+  });
 
-async function main() {
+  return server;
+}
+
+async function startMcpServer(previewBackend: PreviewBackend): Promise<void> {
   mcpLogger.info("MCP Server starting", { version: VERSION });
 
   const transport = new StdioServerTransport();
-  await server.connect(transport);
+  await createMcpServer(previewBackend).connect(transport);
   mcpLogger.info("MCP Server connected via stdio");
   console.error("Claude Mermaid MCP Server running on stdio");
 }
 
-if (!isServeMode) {
-  main().catch((error) => {
-    mcpLogger.error("Fatal error during startup", {
-      error: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-    });
-    console.error("Fatal error:", error);
-    process.exit(1);
-  });
+async function run(): Promise<void> {
+  const options = parseCliOptions();
+
+  if (options.version) {
+    console.log(VERSION);
+    return;
+  }
+
+  if (options.serve) {
+    const { startServeMode } = await import("./serve.js");
+    await startServeMode();
+    return;
+  }
+
+  const previewBackend = createPreviewBackend(resolvePreviewBackendName(options.preview));
+  await startMcpServer(previewBackend);
 }
+
+run().catch((error) => {
+  mcpLogger.error("Fatal error during startup", {
+    error: errorMessage(error),
+    stack: error instanceof Error ? error.stack : undefined,
+  });
+  console.error(`Fatal error: ${errorMessage(error)}`);
+  process.exit(1);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_DIAGRAM_OPTIONS,
 } from "./constants.js";
 import { mcpLogger } from "./logger.js";
+import { createPreviewBackend } from "./preview-backend.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -36,14 +37,15 @@ if (isServeMode) {
   await startServeMode();
 }
 
+const previewBackend = createPreviewBackend();
+
 const TOOL_DEFINITIONS: Tool[] = [
   {
     name: "mermaid_preview",
     description:
-      "Render a Mermaid diagram and open it in browser with live reload. " +
-      "Takes Mermaid diagram code as input and generates a live preview. " +
+      `${previewBackend.toolDescription} ` +
       `Supports themes (${ALLOWED_THEMES.join(", ")}), custom backgrounds, dimensions, and quality scaling. ` +
-      "The diagram will auto-refresh when updated. Use mermaid_save to save to disk. " +
+      "Use mermaid_save to save to disk. " +
       "IMPORTANT: Automatically use this tool whenever you create a Mermaid diagram for the user. " +
       "NOTE: Sequence diagrams do not support style directives - avoid using 'style' statements in sequenceDiagram.",
     inputSchema: {
@@ -152,7 +154,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     let result;
     switch (toolName) {
       case "mermaid_preview":
-        result = await handleMermaidPreview(args);
+        result = await handleMermaidPreview(args, previewBackend);
         mcpLogger.info(`CallTool completed: ${toolName}`);
         return result;
       case "mermaid_save":

--- a/src/live-preview-backend.ts
+++ b/src/live-preview-backend.ts
@@ -1,0 +1,58 @@
+import { spawn } from "child_process";
+import { ensureLiveServer, addLiveDiagram, hasActiveConnections } from "./live-server.js";
+import { getOpenCommand } from "./file-utils.js";
+import { mcpLogger } from "./logger.js";
+import { PREVIEW_BACKENDS } from "./constants.js";
+import type { PreviewBackend, PreviewRequest } from "./types.js";
+
+function openBrowser(previewId: string, serverUrl: string): void {
+  mcpLogger.info(`Opening browser for new diagram: ${previewId}`, { serverUrl });
+  const { command, args } = getOpenCommand(serverUrl);
+  const child = spawn(command, args, { detached: true, stdio: "ignore" });
+  child.on("error", (error) => {
+    mcpLogger.warn("Failed to open browser", { error: error.message, serverUrl });
+  });
+  child.unref();
+}
+
+export class LiveServerPreviewBackend implements PreviewBackend {
+  readonly name = PREVIEW_BACKENDS.LIVE;
+
+  readonly toolDescription =
+    "Render a Mermaid diagram and open it in browser with live reload. " +
+    "Takes Mermaid diagram code as input and generates a live preview. " +
+    "The diagram will auto-refresh when updated.";
+
+  async present({ previewId, filePath, format }: PreviewRequest): Promise<string> {
+    const port = await ensureLiveServer();
+    const hasConnections = hasActiveConnections(previewId);
+
+    await addLiveDiagram(previewId, filePath);
+    const serverUrl = `http://localhost:${port}/${previewId}`;
+
+    if (hasConnections) {
+      mcpLogger.info(`Reusing existing browser tab for diagram: ${previewId}`);
+    } else {
+      openBrowser(previewId, serverUrl);
+    }
+
+    return this.describe(filePath, format, serverUrl, hasConnections);
+  }
+
+  private describe(
+    filePath: string,
+    format: string,
+    serverUrl: string,
+    hasConnections: boolean
+  ): string {
+    const actionMessage = hasConnections
+      ? "Mermaid diagram updated successfully."
+      : "Mermaid diagram rendered successfully and opened in browser.";
+
+    const liveMessage = hasConnections
+      ? "\nDiagram updated. Browser will refresh automatically."
+      : `\nLive reload URL: ${serverUrl}\nThe diagram will auto-refresh when you update it.`;
+
+    return `${actionMessage}\nWorking file: ${filePath} (${format.toUpperCase()})${liveMessage}`;
+  }
+}

--- a/src/live-preview-backend.ts
+++ b/src/live-preview-backend.ts
@@ -2,7 +2,6 @@ import { spawn } from "child_process";
 import { ensureLiveServer, addLiveDiagram, hasActiveConnections } from "./live-server.js";
 import { getOpenCommand } from "./file-utils.js";
 import { mcpLogger } from "./logger.js";
-import { PREVIEW_BACKENDS } from "./constants.js";
 import type { PreviewBackend, PreviewRequest } from "./types.js";
 
 function openBrowser(previewId: string, serverUrl: string): void {
@@ -16,14 +15,12 @@ function openBrowser(previewId: string, serverUrl: string): void {
 }
 
 export class LiveServerPreviewBackend implements PreviewBackend {
-  readonly name = PREVIEW_BACKENDS.LIVE;
-
   readonly toolDescription =
     "Render a Mermaid diagram and open it in browser with live reload. " +
     "Takes Mermaid diagram code as input and generates a live preview. " +
     "The diagram will auto-refresh when updated.";
 
-  async present({ previewId, filePath, format }: PreviewRequest): Promise<string> {
+  async present({ previewId, filePath }: PreviewRequest): Promise<string> {
     const port = await ensureLiveServer();
     const hasConnections = hasActiveConnections(previewId);
 
@@ -36,15 +33,10 @@ export class LiveServerPreviewBackend implements PreviewBackend {
       openBrowser(previewId, serverUrl);
     }
 
-    return this.describe(filePath, format, serverUrl, hasConnections);
+    return this.describe(filePath, serverUrl, hasConnections);
   }
 
-  private describe(
-    filePath: string,
-    format: string,
-    serverUrl: string,
-    hasConnections: boolean
-  ): string {
+  private describe(filePath: string, serverUrl: string, hasConnections: boolean): string {
     const actionMessage = hasConnections
       ? "Mermaid diagram updated successfully."
       : "Mermaid diagram rendered successfully and opened in browser.";
@@ -53,6 +45,6 @@ export class LiveServerPreviewBackend implements PreviewBackend {
       ? "\nDiagram updated. Browser will refresh automatically."
       : `\nLive reload URL: ${serverUrl}\nThe diagram will auto-refresh when you update it.`;
 
-    return `${actionMessage}\nWorking file: ${filePath} (${format.toUpperCase()})${liveMessage}`;
+    return `${actionMessage}\nWorking file: ${filePath} (SVG)${liveMessage}`;
   }
 }

--- a/src/live-server.ts
+++ b/src/live-server.ts
@@ -35,6 +35,7 @@ const PREVIEW_DIR = join(__dirname, "preview");
 const TEMPLATE_PATH = join(PREVIEW_DIR, "template.html");
 const STYLE_PATH = join(PREVIEW_DIR, "style.css");
 const SCRIPT_PATH = join(PREVIEW_DIR, "script.js");
+const VIEWER_SCRIPT_PATH = join(PREVIEW_DIR, "viewer.js");
 const FAVICON_PATH = join(PREVIEW_DIR, "favicon.svg");
 
 let liveServer: HttpServer | null = null;
@@ -288,8 +289,9 @@ export async function ensureLiveServer(): Promise<number> {
         return;
       }
 
-      if (url === ROUTES.SCRIPT) {
-        const js = await readFile(SCRIPT_PATH, "utf-8");
+      if (url === ROUTES.SCRIPT || url === ROUTES.VIEWER_SCRIPT) {
+        const scriptPath = url === ROUTES.SCRIPT ? SCRIPT_PATH : VIEWER_SCRIPT_PATH;
+        const js = await readFile(scriptPath, "utf-8");
         res.writeHead(200, { "Content-Type": CONTENT_TYPES.JAVASCRIPT });
         res.end(js);
         return;

--- a/src/live-server.ts
+++ b/src/live-server.ts
@@ -15,6 +15,7 @@ import {
 import { renderDiagram } from "./handlers.js";
 import { webLogger } from "./logger.js";
 import { matchRoute } from "./routes.js";
+import { loadTemplate, fillTemplate, diagramPageData } from "./page-renderer.js";
 import { DiagramState } from "./types.js";
 import {
   CSP_HEADER,
@@ -26,16 +27,14 @@ import {
   CACHE_CONTROL,
   WS_MESSAGES,
   DEFAULT_DIAGRAM_OPTIONS,
-  TEMPLATE_VARS,
+  TEMPLATE_FILES,
 } from "./constants.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const PREVIEW_DIR = join(__dirname, "preview");
-const TEMPLATE_PATH = join(PREVIEW_DIR, "template.html");
 const STYLE_PATH = join(PREVIEW_DIR, "style.css");
 const SCRIPT_PATH = join(PREVIEW_DIR, "script.js");
-const VIEWER_SCRIPT_PATH = join(PREVIEW_DIR, "viewer.js");
 const FAVICON_PATH = join(PREVIEW_DIR, "favicon.svg");
 
 let liveServer: HttpServer | null = null;
@@ -289,9 +288,8 @@ export async function ensureLiveServer(): Promise<number> {
         return;
       }
 
-      if (url === ROUTES.SCRIPT || url === ROUTES.VIEWER_SCRIPT) {
-        const scriptPath = url === ROUTES.SCRIPT ? SCRIPT_PATH : VIEWER_SCRIPT_PATH;
-        const js = await readFile(scriptPath, "utf-8");
+      if (url === ROUTES.SCRIPT) {
+        const js = await readFile(SCRIPT_PATH, "utf-8");
         res.writeHead(200, { "Content-Type": CONTENT_TYPES.JAVASCRIPT });
         res.end(js);
         return;
@@ -437,27 +435,6 @@ function notifyClients(diagramId: string): void {
   }
 }
 
-let templateCache: string | null = null;
-
-async function loadTemplate(): Promise<string> {
-  if (!templateCache) {
-    templateCache = await readFile(TEMPLATE_PATH, "utf-8");
-  }
-  return templateCache;
-}
-
-/**
- * Escapes HTML special characters to prevent XSS attacks
- */
-export function escapeHtml(unsafe: string): string {
-  return unsafe
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}
-
 /**
  * Closes the live server and cleans up all resources.
  * This is safe to call multiple times and useful for graceful shutdown.
@@ -506,16 +483,10 @@ async function createLiveHtmlWrapper(
   background: string = "white",
   liveEnabled: boolean = true
 ): Promise<string> {
-  const template = await loadTemplate();
-
-  // Escape user-controlled values
-  // CONTENT is SVG from mermaid-cli - trusted
-  // DIAGRAM_ID, BACKGROUND, TIMESTAMP need escaping
-  return template
-    .replaceAll(TEMPLATE_VARS.CONTENT, content)
-    .replaceAll(TEMPLATE_VARS.DIAGRAM_ID, escapeHtml(diagramId))
-    .replaceAll(TEMPLATE_VARS.PORT, port.toString())
-    .replaceAll(TEMPLATE_VARS.BACKGROUND, escapeHtml(background))
-    .replaceAll(TEMPLATE_VARS.TIMESTAMP, escapeHtml(new Date().toLocaleTimeString()))
-    .replaceAll(TEMPLATE_VARS.LIVE_ENABLED, liveEnabled ? "true" : "false");
+  const template = await loadTemplate(TEMPLATE_FILES.DIAGRAM);
+  return fillTemplate(template, {
+    PORT: port.toString(),
+    LIVE_ENABLED: liveEnabled ? "true" : "false",
+    ...diagramPageData(diagramId, content, background),
+  });
 }

--- a/src/page-renderer.ts
+++ b/src/page-renderer.ts
@@ -24,7 +24,7 @@ const templateCache = new Map<string, string>();
  * @param filename Template filename
  * @returns Template content
  */
-async function loadTemplate(filename: string): Promise<string> {
+export async function loadTemplate(filename: string): Promise<string> {
   if (templateCache.has(filename)) {
     return templateCache.get(filename)!;
   }

--- a/src/page-renderer.ts
+++ b/src/page-renderer.ts
@@ -8,7 +8,7 @@ import { readFile } from "fs/promises";
 import { join } from "path";
 import { fileURLToPath } from "url";
 import { dirname } from "path";
-import { TEMPLATE_VARS, ROUTES } from "./constants.js";
+import { ROUTES } from "./constants.js";
 import { PageData, PageRenderOptions } from "./types.js";
 import { webLogger } from "./logger.js";
 
@@ -59,16 +59,33 @@ export function escapeHtml(unsafe: string): string {
  * @returns Processed template
  */
 function replaceVariables(template: string, data: PageData, escape: boolean = true): string {
-  let result = template;
+  const values = Object.fromEntries(
+    Object.entries(data).map(([key, value]) => {
+      const stringValue = String(value ?? "");
+      return [key, escape ? escapeHtml(stringValue) : stringValue];
+    })
+  );
+  return fillTemplate(template, values);
+}
 
-  for (const [key, value] of Object.entries(data)) {
-    const placeholder = `{{${key}}}`;
-    const stringValue = String(value ?? "");
-    const processedValue = escape ? escapeHtml(stringValue) : stringValue;
-    result = result.replaceAll(placeholder, processedValue);
-  }
+export function fillTemplate(template: string, values: Record<string, string>): string {
+  return Object.entries(values).reduce(
+    (page, [key, value]) => page.replaceAll(`{{${key}}}`, () => value),
+    template
+  );
+}
 
-  return result;
+export function diagramPageData(
+  previewId: string,
+  svg: string,
+  background: string
+): Record<string, string> {
+  return {
+    DIAGRAM_ID: escapeHtml(previewId),
+    BACKGROUND: escapeHtml(background),
+    TIMESTAMP: escapeHtml(new Date().toLocaleTimeString()),
+    CONTENT: svg,
+  };
 }
 
 /**

--- a/src/preview-backend.ts
+++ b/src/preview-backend.ts
@@ -1,0 +1,48 @@
+import {
+  ALLOWED_PREVIEW_BACKENDS,
+  DEFAULT_PREVIEW_BACKEND,
+  PREVIEW_BACKENDS,
+  PREVIEW_BACKEND_ENV_VAR,
+  PREVIEW_BACKEND_FLAG,
+  type PreviewBackendName,
+} from "./constants.js";
+import type { PreviewBackend } from "./types.js";
+import { LiveServerPreviewBackend } from "./live-preview-backend.js";
+import { ArtifactPreviewBackend } from "./artifact-preview-backend.js";
+
+function readFlagValue(argv: readonly string[]): string | undefined {
+  const flagIndex = argv.indexOf(PREVIEW_BACKEND_FLAG);
+  if (flagIndex !== -1) {
+    return argv[flagIndex + 1];
+  }
+  const inline = argv.find((arg) => arg.startsWith(`${PREVIEW_BACKEND_FLAG}=`));
+  return inline?.slice(PREVIEW_BACKEND_FLAG.length + 1);
+}
+
+function isPreviewBackendName(value: string): value is PreviewBackendName {
+  return (ALLOWED_PREVIEW_BACKENDS as readonly string[]).includes(value);
+}
+
+export function resolvePreviewBackendName(
+  argv: readonly string[] = process.argv,
+  env: NodeJS.ProcessEnv = process.env
+): PreviewBackendName {
+  const requested = readFlagValue(argv) ?? env[PREVIEW_BACKEND_ENV_VAR] ?? DEFAULT_PREVIEW_BACKEND;
+  if (!isPreviewBackendName(requested)) {
+    throw new Error(
+      `Invalid preview backend: "${requested}". Allowed values: ${ALLOWED_PREVIEW_BACKENDS.join(", ")}.`
+    );
+  }
+  return requested;
+}
+
+export function createPreviewBackend(
+  name: PreviewBackendName = resolvePreviewBackendName()
+): PreviewBackend {
+  switch (name) {
+    case PREVIEW_BACKENDS.ARTIFACT:
+      return new ArtifactPreviewBackend();
+    case PREVIEW_BACKENDS.LIVE:
+      return new LiveServerPreviewBackend();
+  }
+}

--- a/src/preview-backend.ts
+++ b/src/preview-backend.ts
@@ -1,26 +1,18 @@
 import {
-  ALLOWED_PREVIEW_BACKENDS,
   DEFAULT_PREVIEW_BACKEND,
   PREVIEW_BACKENDS,
   PREVIEW_BACKEND_ENV_VAR,
   PREVIEW_BACKEND_FLAG,
   type PreviewBackendName,
 } from "./constants.js";
+import { validatePreviewBackend } from "./file-utils.js";
 import type { PreviewBackend } from "./types.js";
 import { LiveServerPreviewBackend } from "./live-preview-backend.js";
 import { ArtifactPreviewBackend } from "./artifact-preview-backend.js";
 
 function readFlagValue(argv: readonly string[]): string | undefined {
   const flagIndex = argv.indexOf(PREVIEW_BACKEND_FLAG);
-  if (flagIndex !== -1) {
-    return argv[flagIndex + 1];
-  }
-  const inline = argv.find((arg) => arg.startsWith(`${PREVIEW_BACKEND_FLAG}=`));
-  return inline?.slice(PREVIEW_BACKEND_FLAG.length + 1);
-}
-
-function isPreviewBackendName(value: string): value is PreviewBackendName {
-  return (ALLOWED_PREVIEW_BACKENDS as readonly string[]).includes(value);
+  return flagIndex === -1 ? undefined : argv[flagIndex + 1];
 }
 
 export function resolvePreviewBackendName(
@@ -28,11 +20,7 @@ export function resolvePreviewBackendName(
   env: NodeJS.ProcessEnv = process.env
 ): PreviewBackendName {
   const requested = readFlagValue(argv) ?? env[PREVIEW_BACKEND_ENV_VAR] ?? DEFAULT_PREVIEW_BACKEND;
-  if (!isPreviewBackendName(requested)) {
-    throw new Error(
-      `Invalid preview backend: "${requested}". Allowed values: ${ALLOWED_PREVIEW_BACKENDS.join(", ")}.`
-    );
-  }
+  validatePreviewBackend(requested);
   return requested;
 }
 

--- a/src/preview-backend.ts
+++ b/src/preview-backend.ts
@@ -2,7 +2,6 @@ import {
   DEFAULT_PREVIEW_BACKEND,
   PREVIEW_BACKENDS,
   PREVIEW_BACKEND_ENV_VAR,
-  PREVIEW_BACKEND_FLAG,
   type PreviewBackendName,
 } from "./constants.js";
 import { validatePreviewBackend } from "./file-utils.js";
@@ -10,23 +9,16 @@ import type { PreviewBackend } from "./types.js";
 import { LiveServerPreviewBackend } from "./live-preview-backend.js";
 import { ArtifactPreviewBackend } from "./artifact-preview-backend.js";
 
-function readFlagValue(argv: readonly string[]): string | undefined {
-  const flagIndex = argv.indexOf(PREVIEW_BACKEND_FLAG);
-  return flagIndex === -1 ? undefined : argv[flagIndex + 1];
-}
-
 export function resolvePreviewBackendName(
-  argv: readonly string[] = process.argv,
+  requested: string | undefined,
   env: NodeJS.ProcessEnv = process.env
 ): PreviewBackendName {
-  const requested = readFlagValue(argv) ?? env[PREVIEW_BACKEND_ENV_VAR] ?? DEFAULT_PREVIEW_BACKEND;
-  validatePreviewBackend(requested);
-  return requested;
+  const name = requested ?? env[PREVIEW_BACKEND_ENV_VAR] ?? DEFAULT_PREVIEW_BACKEND;
+  validatePreviewBackend(name);
+  return name;
 }
 
-export function createPreviewBackend(
-  name: PreviewBackendName = resolvePreviewBackendName()
-): PreviewBackend {
+export function createPreviewBackend(name: PreviewBackendName): PreviewBackend {
   switch (name) {
     case PREVIEW_BACKENDS.ARTIFACT:
       return new ArtifactPreviewBackend();

--- a/src/preview/artifact-template.html
+++ b/src/preview/artifact-template.html
@@ -1,9 +1,9 @@
-<title>{{TITLE}}</title>
-{{STYLES}}
-<div class="preview" data-diagram-id="{{DIAGRAM_ID}}" data-live-enabled="false">
+<title>{{PAGE_TITLE}}</title>
+{{PAGE_STYLES}}
+<div class="preview" data-diagram-id="{{DIAGRAM_ID}}">
   <div class="status-bar">
     <div class="status-group">
-      <span class="status-title">{{TITLE}}</span>
+      <span class="status-title">{{PAGE_TITLE}}</span>
       <div class="toolbar-buttons">
         <button class="toolbar-btn" id="zoom-out" title="Zoom out">−</button>
         <span class="zoom-level" id="zoom-level">100%</span>
@@ -19,4 +19,4 @@
     <div class="diagram-wrapper">{{CONTENT}}</div>
   </div>
 </div>
-{{SCRIPT}}
+{{PAGE_SCRIPTS}}

--- a/src/preview/artifact.html
+++ b/src/preview/artifact.html
@@ -1,0 +1,22 @@
+<title>{{TITLE}}</title>
+{{STYLES}}
+<div class="preview" data-diagram-id="{{DIAGRAM_ID}}" data-live-enabled="false">
+  <div class="status-bar">
+    <div class="status-group">
+      <span class="status-title">{{TITLE}}</span>
+      <div class="toolbar-buttons">
+        <button class="toolbar-btn" id="zoom-out" title="Zoom out">−</button>
+        <span class="zoom-level" id="zoom-level">100%</span>
+        <button class="toolbar-btn" id="zoom-in" title="Zoom in">+</button>
+        <button class="toolbar-btn" id="reset-pan" title="Reset position">⊙</button>
+        <button class="toolbar-btn" id="copy-svg" title="Copy SVG to clipboard">⎘</button>
+      </div>
+    </div>
+    <div id="last-update">Last updated: {{TIMESTAMP}}</div>
+  </div>
+
+  <div class="viewport" style="background: {{BACKGROUND}}">
+    <div class="diagram-wrapper">{{CONTENT}}</div>
+  </div>
+</div>
+{{SCRIPT}}

--- a/src/preview/script.js
+++ b/src/preview/script.js
@@ -3,7 +3,11 @@
 
 (function () {
   const viewer = window.ClaudeMermaidViewer;
-  const config = viewer.config;
+  const config = {
+    diagramId: viewer.diagramId,
+    port: viewer.root.dataset.port,
+    liveEnabled: viewer.root.dataset.liveEnabled === "true",
+  };
 
   const elements = {
     statusText: document.getElementById("status-text"),
@@ -112,7 +116,7 @@
   }
 
   function exportSvg() {
-    if (!viewer.hasSvg()) {
+    if (!viewer.svg) {
       alert("No diagram found to export.");
       return;
     }

--- a/src/preview/script.js
+++ b/src/preview/script.js
@@ -1,48 +1,19 @@
-// Preview page functionality
-// Configuration is read from data attributes on the body element
+// Live preview page: websocket reload, export and editor links
+// Depends on viewer.js for configuration and SVG access
 
 (function () {
-  // ===== Configuration =====
-  const config = {
-    diagramId: document.body.dataset.diagramId,
-    port: document.body.dataset.port,
-    liveEnabled: document.body.dataset.liveEnabled === "true",
-  };
+  const viewer = window.ClaudeMermaidViewer;
+  const config = viewer.config;
 
-  // ===== Constants =====
-  const MIN_SCALE = 0.1;
-  const MAX_SCALE = 10;
-  const ZOOM_BUTTON_FACTOR = 1.2;
-  const WHEEL_ZOOM_FACTOR = 0.001;
-
-  // ===== DOM Elements =====
   const elements = {
-    viewport: document.querySelector(".viewport"),
-    diagramWrapper: document.querySelector(".diagram-wrapper"),
-    svg: document.querySelector("svg"),
     statusText: document.getElementById("status-text"),
     statusIndicator: document.getElementById("status-indicator"),
-    resetButton: document.getElementById("reset-pan"),
-    zoomInButton: document.getElementById("zoom-in"),
-    zoomOutButton: document.getElementById("zoom-out"),
-    zoomLevel: document.getElementById("zoom-level"),
     openLiveButton: document.getElementById("open-mermaid-live"),
     backToGalleryButton: document.getElementById("back-to-gallery"),
     exportButton: document.getElementById("export-btn"),
     exportMenu: document.getElementById("export-menu"),
   };
 
-  // ===== Pan/Zoom State =====
-  const panState = {
-    x: 0,
-    y: 0,
-    scale: 1,
-    isDragging: false,
-    dragStartX: 0,
-    dragStartY: 0,
-  };
-
-  // ===== WebSocket State =====
   const wsState = {
     connection: null,
     reconnectInterval: null,
@@ -50,115 +21,7 @@
     maxReconnectAttempts: 30,
   };
 
-  // ===== Pan/Zoom Functions =====
-  function clampScale(value) {
-    return Math.min(MAX_SCALE, Math.max(MIN_SCALE, value));
-  }
-
-  function updateZoomLevel() {
-    if (elements.zoomLevel) {
-      elements.zoomLevel.textContent = `${Math.round(panState.scale * 100)}%`;
-    }
-  }
-
-  function resetView() {
-    panState.x = 0;
-    panState.y = 0;
-    panState.scale = 1;
-    applyTransform();
-    updateZoomLevel();
-  }
-
-  function applyTransform() {
-    if (elements.diagramWrapper) {
-      elements.diagramWrapper.style.transform = `translate(${panState.x}px, ${panState.y}px) scale(${panState.scale})`;
-    }
-  }
-
-  function zoomAtPoint(newScale, pivotX, pivotY) {
-    newScale = clampScale(newScale);
-    const ratio = 1 - newScale / panState.scale;
-    panState.x += (pivotX - panState.x) * ratio;
-    panState.y += (pivotY - panState.y) * ratio;
-    panState.scale = newScale;
-    applyTransform();
-    updateZoomLevel();
-  }
-
-  function zoomAtCenter(newScale) {
-    if (!elements.viewport) return;
-    const rect = elements.viewport.getBoundingClientRect();
-    zoomAtPoint(newScale, rect.width / 2, rect.height / 2);
-  }
-
-  function normalizeWheelDelta(e) {
-    var deltaY = e.deltaY;
-    if (e.deltaMode === 1) deltaY *= 40;
-    else if (e.deltaMode === 2) deltaY *= 800;
-    return deltaY;
-  }
-
-  function handleWheel(e) {
-    if (!elements.viewport) return;
-    e.preventDefault();
-
-    const rect = elements.viewport.getBoundingClientRect();
-    const pivotX = e.clientX - rect.left;
-    const pivotY = e.clientY - rect.top;
-
-    const delta = -normalizeWheelDelta(e) * WHEEL_ZOOM_FACTOR;
-    const newScale = panState.scale * (1 + delta);
-    zoomAtPoint(newScale, pivotX, pivotY);
-  }
-
-  function handleMouseDown(e) {
-    if (!elements.viewport || e.target.closest(".status-bar")) return;
-    panState.isDragging = true;
-    panState.dragStartX = e.clientX - panState.x;
-    panState.dragStartY = e.clientY - panState.y;
-    elements.viewport.style.cursor = "grabbing";
-    e.preventDefault();
-  }
-
-  function handleMouseUp() {
-    panState.isDragging = false;
-    if (elements.viewport) {
-      elements.viewport.style.cursor = "grab";
-    }
-  }
-
-  function handleMouseMove(e) {
-    if (!elements.viewport) return;
-    if (panState.isDragging) {
-      panState.x = e.clientX - panState.dragStartX;
-      panState.y = e.clientY - panState.dragStartY;
-      applyTransform();
-    }
-  }
-
-  // ===== Touch Event Handlers =====
-  function handleTouchStart(e) {
-    if (!elements.viewport || e.target.closest(".status-bar")) return;
-    if (e.touches.length !== 1) return;
-    panState.isDragging = true;
-    panState.dragStartX = e.touches[0].clientX - panState.x;
-    panState.dragStartY = e.touches[0].clientY - panState.y;
-    e.preventDefault();
-  }
-
-  function handleTouchMove(e) {
-    if (!panState.isDragging || e.touches.length !== 1) return;
-    panState.x = e.touches[0].clientX - panState.dragStartX;
-    panState.y = e.touches[0].clientY - panState.dragStartY;
-    applyTransform();
-    e.preventDefault();
-  }
-
-  function handleTouchEnd() {
-    panState.isDragging = false;
-  }
-
-  // ===== Status Update Functions =====
+  // ===== Status =====
   function setStatus(text, isConnected) {
     if (elements.statusText) {
       elements.statusText.textContent = text;
@@ -168,7 +31,7 @@
     }
   }
 
-  // ===== WebSocket Functions =====
+  // ===== WebSocket =====
   function handleWebSocketOpen() {
     console.log("WebSocket connected");
     setStatus("Live Reload Active", true);
@@ -232,7 +95,7 @@
     wsState.connection.onerror = handleWebSocketError;
   }
 
-  // ===== Export Functions =====
+  // ===== Export =====
   function getFilename(format) {
     return `${config.diagramId || "diagram"}.${format}`;
   }
@@ -249,18 +112,12 @@
   }
 
   function exportSvg() {
-    if (!elements.svg) {
+    if (!viewer.hasSvg()) {
       alert("No diagram found to export.");
       return;
     }
 
-    const svgClone = elements.svg.cloneNode(true);
-    svgClone.removeAttribute("style");
-    svgClone.style.maxWidth = "none";
-    svgClone.style.maxHeight = "none";
-
-    const svgData = new XMLSerializer().serializeToString(svgClone);
-    const blob = new Blob([svgData], { type: "image/svg+xml;charset=utf-8" });
+    const blob = new Blob([viewer.serializeSvg()], { type: "image/svg+xml;charset=utf-8" });
     downloadBlob(blob, getFilename("svg"));
   }
 
@@ -311,7 +168,7 @@
     }
   }
 
-  // ===== External Editor Functions =====
+  // ===== External editor =====
   function handleOpenMermaidLive() {
     if (!config.diagramId) {
       alert("Diagram identifier is missing. Try rendering the diagram again.");
@@ -355,30 +212,7 @@
   }
 
   // ===== Initialization =====
-  function initializePanZoom() {
-    if (elements.viewport) {
-      elements.viewport.addEventListener("mousedown", handleMouseDown);
-      document.addEventListener("mouseup", handleMouseUp);
-      elements.viewport.addEventListener("mousemove", handleMouseMove);
-      elements.viewport.addEventListener("wheel", handleWheel, { passive: false });
-      elements.viewport.addEventListener("touchstart", handleTouchStart, { passive: false });
-      elements.viewport.addEventListener("touchmove", handleTouchMove, { passive: false });
-      elements.viewport.addEventListener("touchend", handleTouchEnd);
-      elements.viewport.style.cursor = "grab";
-    }
-    if (elements.resetButton) {
-      elements.resetButton.addEventListener("click", resetView);
-    }
-    if (elements.zoomInButton) {
-      elements.zoomInButton.addEventListener("click", function () {
-        zoomAtCenter(panState.scale * ZOOM_BUTTON_FACTOR);
-      });
-    }
-    if (elements.zoomOutButton) {
-      elements.zoomOutButton.addEventListener("click", function () {
-        zoomAtCenter(panState.scale / ZOOM_BUTTON_FACTOR);
-      });
-    }
+  function initializeToolbar() {
     if (elements.openLiveButton) {
       elements.openLiveButton.addEventListener("click", handleOpenMermaidLive);
     }
@@ -387,14 +221,12 @@
         window.location.href = "/";
       });
     }
-
     if (elements.exportButton) {
       elements.exportButton.addEventListener("click", function (e) {
         e.stopPropagation();
         toggleExportMenu();
       });
     }
-
     if (elements.exportMenu) {
       elements.exportMenu.querySelectorAll(".export-option").forEach(function (btn) {
         btn.addEventListener("click", function () {
@@ -402,7 +234,6 @@
         });
       });
     }
-
     document.addEventListener("click", function (e) {
       if (!e.target.closest(".export-dropdown")) {
         hideExportMenu();
@@ -418,12 +249,6 @@
     connectWebSocket();
   }
 
-  function initialize() {
-    initializePanZoom();
-    initializeWebSocket();
-  }
-
-  // Cleanup on page unload
   function cleanup() {
     if (wsState.connection) {
       wsState.connection.close();
@@ -435,9 +260,8 @@
     }
   }
 
-  // Register cleanup handler
   window.addEventListener("beforeunload", cleanup);
 
-  // Start the application
-  initialize();
+  initializeToolbar();
+  initializeWebSocket();
 })();

--- a/src/preview/style.css
+++ b/src/preview/style.css
@@ -13,6 +13,23 @@ body {
   flex-direction: column;
 }
 
+.preview {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.status-group {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.status-title {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
 .status-bar {
   height: 32px;
   padding: 8px 16px;

--- a/src/preview/style.css
+++ b/src/preview/style.css
@@ -5,12 +5,9 @@
 body {
   margin: 0;
   padding: 0;
-  height: 100vh;
   overflow: hidden;
   background: #1a1a1a;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  display: flex;
-  flex-direction: column;
 }
 
 .preview {

--- a/src/preview/template.html
+++ b/src/preview/template.html
@@ -37,6 +37,7 @@
       <div class="diagram-wrapper">{{CONTENT}}</div>
     </div>
 
+    <script src="/viewer.js"></script>
     <script src="/script.js"></script>
   </body>
 </html>

--- a/src/preview/template.html
+++ b/src/preview/template.html
@@ -7,34 +7,43 @@
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="/style.css" />
   </head>
-  <body data-diagram-id="{{DIAGRAM_ID}}" data-port="{{PORT}}" data-live-enabled="{{LIVE_ENABLED}}">
-    <div class="status-bar">
-      <div style="display: flex; align-items: center; gap: 12px">
-        <div>
-          <span class="status-indicator" id="status-indicator"></span>
-          <span id="status-text">Live Reload Active</span>
-        </div>
-        <div class="toolbar-buttons">
-          <button class="toolbar-btn" id="back-to-gallery" title="Back to gallery">◄</button>
-          <button class="toolbar-btn" id="zoom-out" title="Zoom out">−</button>
-          <span class="zoom-level" id="zoom-level">100%</span>
-          <button class="toolbar-btn" id="zoom-in" title="Zoom in">+</button>
-          <button class="toolbar-btn" id="reset-pan" title="Reset position">⊙</button>
-          <div class="export-dropdown">
-            <button class="toolbar-btn" id="export-btn" title="Export diagram">⬇</button>
-            <div class="export-menu" id="export-menu">
-              <button class="export-option" data-format="svg">Download SVG</button>
-              <button class="export-option" data-format="png">Download PNG</button>
-            </div>
+  <body>
+    <div
+      class="preview"
+      data-diagram-id="{{DIAGRAM_ID}}"
+      data-port="{{PORT}}"
+      data-live-enabled="{{LIVE_ENABLED}}"
+    >
+      <div class="status-bar">
+        <div class="status-group">
+          <div>
+            <span class="status-indicator" id="status-indicator"></span>
+            <span id="status-text">Live Reload Active</span>
           </div>
-          <button class="toolbar-btn" id="open-mermaid-live" title="Open in Mermaid Live">⧉</button>
+          <div class="toolbar-buttons">
+            <button class="toolbar-btn" id="back-to-gallery" title="Back to gallery">◄</button>
+            <button class="toolbar-btn" id="zoom-out" title="Zoom out">−</button>
+            <span class="zoom-level" id="zoom-level">100%</span>
+            <button class="toolbar-btn" id="zoom-in" title="Zoom in">+</button>
+            <button class="toolbar-btn" id="reset-pan" title="Reset position">⊙</button>
+            <div class="export-dropdown">
+              <button class="toolbar-btn" id="export-btn" title="Export diagram">⬇</button>
+              <div class="export-menu" id="export-menu">
+                <button class="export-option" data-format="svg">Download SVG</button>
+                <button class="export-option" data-format="png">Download PNG</button>
+              </div>
+            </div>
+            <button class="toolbar-btn" id="open-mermaid-live" title="Open in Mermaid Live">
+              ⧉
+            </button>
+          </div>
         </div>
+        <div id="last-update">Last updated: {{TIMESTAMP}}</div>
       </div>
-      <div id="last-update">Last updated: {{TIMESTAMP}}</div>
-    </div>
 
-    <div class="viewport" style="background: {{BACKGROUND}}">
-      <div class="diagram-wrapper">{{CONTENT}}</div>
+      <div class="viewport" style="background: {{BACKGROUND}}">
+        <div class="diagram-wrapper">{{CONTENT}}</div>
+      </div>
     </div>
 
     <script src="/viewer.js"></script>

--- a/src/preview/viewer.js
+++ b/src/preview/viewer.js
@@ -1,20 +1,13 @@
 // Diagram viewer: pan, zoom and copy controls shared by the live preview and artifact pages
-// Configuration is read from data attributes on the element carrying data-diagram-id
 
 (function () {
-  const configRoot = document.querySelector("[data-diagram-id]") || document.body;
-  const config = {
-    diagramId: configRoot.dataset.diagramId,
-    port: configRoot.dataset.port,
-    liveEnabled: configRoot.dataset.liveEnabled === "true",
-  };
+  const root = document.querySelector(".preview");
 
   const MIN_SCALE = 0.1;
   const MAX_SCALE = 10;
   const ZOOM_BUTTON_FACTOR = 1.2;
   const WHEEL_ZOOM_FACTOR = 0.001;
   const COPY_FEEDBACK_MS = 1500;
-  const COPY_DONE_LABEL = "✓";
 
   const elements = {
     viewport: document.querySelector(".viewport"),
@@ -164,7 +157,7 @@
     navigator.clipboard
       .writeText(serializeSvg())
       .then(function () {
-        flashButtonLabel(elements.copySvgButton, COPY_DONE_LABEL);
+        flashButtonLabel(elements.copySvgButton, "✓");
       })
       .catch(function (error) {
         console.error("Copy SVG failed", error);
@@ -204,10 +197,9 @@
   initialize();
 
   window.ClaudeMermaidViewer = {
-    config: config,
-    hasSvg: function () {
-      return Boolean(elements.svg);
-    },
+    root: root,
+    diagramId: root.dataset.diagramId,
+    svg: elements.svg,
     serializeSvg: serializeSvg,
   };
 })();

--- a/src/preview/viewer.js
+++ b/src/preview/viewer.js
@@ -153,7 +153,7 @@
   }
 
   function copySvg() {
-    if (!elements.svg || !navigator.clipboard) return;
+    if (!elements.svg) return;
     navigator.clipboard
       .writeText(serializeSvg())
       .then(function () {
@@ -161,7 +161,17 @@
       })
       .catch(function (error) {
         console.error("Copy SVG failed", error);
+        flashButtonLabel(elements.copySvgButton, "✕");
       });
+  }
+
+  function initializeCopyButton(button) {
+    if (!navigator.clipboard) {
+      button.disabled = true;
+      button.title = "Clipboard is not available in this context";
+      return;
+    }
+    button.addEventListener("click", copySvg);
   }
 
   // ===== Initialization =====
@@ -190,7 +200,7 @@
       });
     }
     if (elements.copySvgButton) {
-      elements.copySvgButton.addEventListener("click", copySvg);
+      initializeCopyButton(elements.copySvgButton);
     }
   }
 

--- a/src/preview/viewer.js
+++ b/src/preview/viewer.js
@@ -1,0 +1,213 @@
+// Diagram viewer: pan, zoom and copy controls shared by the live preview and artifact pages
+// Configuration is read from data attributes on the element carrying data-diagram-id
+
+(function () {
+  const configRoot = document.querySelector("[data-diagram-id]") || document.body;
+  const config = {
+    diagramId: configRoot.dataset.diagramId,
+    port: configRoot.dataset.port,
+    liveEnabled: configRoot.dataset.liveEnabled === "true",
+  };
+
+  const MIN_SCALE = 0.1;
+  const MAX_SCALE = 10;
+  const ZOOM_BUTTON_FACTOR = 1.2;
+  const WHEEL_ZOOM_FACTOR = 0.001;
+  const COPY_FEEDBACK_MS = 1500;
+  const COPY_DONE_LABEL = "✓";
+
+  const elements = {
+    viewport: document.querySelector(".viewport"),
+    diagramWrapper: document.querySelector(".diagram-wrapper"),
+    svg: document.querySelector("svg"),
+    resetButton: document.getElementById("reset-pan"),
+    zoomInButton: document.getElementById("zoom-in"),
+    zoomOutButton: document.getElementById("zoom-out"),
+    zoomLevel: document.getElementById("zoom-level"),
+    copySvgButton: document.getElementById("copy-svg"),
+  };
+
+  const panState = {
+    x: 0,
+    y: 0,
+    scale: 1,
+    isDragging: false,
+    dragStartX: 0,
+    dragStartY: 0,
+  };
+
+  // ===== Pan/Zoom =====
+  function clampScale(value) {
+    return Math.min(MAX_SCALE, Math.max(MIN_SCALE, value));
+  }
+
+  function updateZoomLevel() {
+    if (elements.zoomLevel) {
+      elements.zoomLevel.textContent = `${Math.round(panState.scale * 100)}%`;
+    }
+  }
+
+  function applyTransform() {
+    if (elements.diagramWrapper) {
+      elements.diagramWrapper.style.transform = `translate(${panState.x}px, ${panState.y}px) scale(${panState.scale})`;
+    }
+  }
+
+  function resetView() {
+    panState.x = 0;
+    panState.y = 0;
+    panState.scale = 1;
+    applyTransform();
+    updateZoomLevel();
+  }
+
+  function zoomAtPoint(newScale, pivotX, pivotY) {
+    newScale = clampScale(newScale);
+    const ratio = 1 - newScale / panState.scale;
+    panState.x += (pivotX - panState.x) * ratio;
+    panState.y += (pivotY - panState.y) * ratio;
+    panState.scale = newScale;
+    applyTransform();
+    updateZoomLevel();
+  }
+
+  function zoomAtCenter(newScale) {
+    if (!elements.viewport) return;
+    const rect = elements.viewport.getBoundingClientRect();
+    zoomAtPoint(newScale, rect.width / 2, rect.height / 2);
+  }
+
+  function normalizeWheelDelta(e) {
+    var deltaY = e.deltaY;
+    if (e.deltaMode === 1) deltaY *= 40;
+    else if (e.deltaMode === 2) deltaY *= 800;
+    return deltaY;
+  }
+
+  function handleWheel(e) {
+    if (!elements.viewport) return;
+    e.preventDefault();
+
+    const rect = elements.viewport.getBoundingClientRect();
+    const pivotX = e.clientX - rect.left;
+    const pivotY = e.clientY - rect.top;
+
+    const delta = -normalizeWheelDelta(e) * WHEEL_ZOOM_FACTOR;
+    zoomAtPoint(panState.scale * (1 + delta), pivotX, pivotY);
+  }
+
+  function handleMouseDown(e) {
+    if (!elements.viewport || e.target.closest(".status-bar")) return;
+    panState.isDragging = true;
+    panState.dragStartX = e.clientX - panState.x;
+    panState.dragStartY = e.clientY - panState.y;
+    elements.viewport.style.cursor = "grabbing";
+    e.preventDefault();
+  }
+
+  function handleMouseUp() {
+    panState.isDragging = false;
+    if (elements.viewport) {
+      elements.viewport.style.cursor = "grab";
+    }
+  }
+
+  function handleMouseMove(e) {
+    if (!elements.viewport || !panState.isDragging) return;
+    panState.x = e.clientX - panState.dragStartX;
+    panState.y = e.clientY - panState.dragStartY;
+    applyTransform();
+  }
+
+  function handleTouchStart(e) {
+    if (!elements.viewport || e.target.closest(".status-bar")) return;
+    if (e.touches.length !== 1) return;
+    panState.isDragging = true;
+    panState.dragStartX = e.touches[0].clientX - panState.x;
+    panState.dragStartY = e.touches[0].clientY - panState.y;
+    e.preventDefault();
+  }
+
+  function handleTouchMove(e) {
+    if (!panState.isDragging || e.touches.length !== 1) return;
+    panState.x = e.touches[0].clientX - panState.dragStartX;
+    panState.y = e.touches[0].clientY - panState.dragStartY;
+    applyTransform();
+    e.preventDefault();
+  }
+
+  function handleTouchEnd() {
+    panState.isDragging = false;
+  }
+
+  // ===== SVG access =====
+  function serializeSvg() {
+    const svgClone = elements.svg.cloneNode(true);
+    svgClone.removeAttribute("style");
+    svgClone.style.maxWidth = "none";
+    svgClone.style.maxHeight = "none";
+    return new XMLSerializer().serializeToString(svgClone);
+  }
+
+  function flashButtonLabel(button, label) {
+    const original = button.textContent;
+    button.textContent = label;
+    button.disabled = true;
+    setTimeout(function () {
+      button.textContent = original;
+      button.disabled = false;
+    }, COPY_FEEDBACK_MS);
+  }
+
+  function copySvg() {
+    if (!elements.svg || !navigator.clipboard) return;
+    navigator.clipboard
+      .writeText(serializeSvg())
+      .then(function () {
+        flashButtonLabel(elements.copySvgButton, COPY_DONE_LABEL);
+      })
+      .catch(function (error) {
+        console.error("Copy SVG failed", error);
+      });
+  }
+
+  // ===== Initialization =====
+  function initialize() {
+    if (elements.viewport) {
+      elements.viewport.addEventListener("mousedown", handleMouseDown);
+      document.addEventListener("mouseup", handleMouseUp);
+      elements.viewport.addEventListener("mousemove", handleMouseMove);
+      elements.viewport.addEventListener("wheel", handleWheel, { passive: false });
+      elements.viewport.addEventListener("touchstart", handleTouchStart, { passive: false });
+      elements.viewport.addEventListener("touchmove", handleTouchMove, { passive: false });
+      elements.viewport.addEventListener("touchend", handleTouchEnd);
+      elements.viewport.style.cursor = "grab";
+    }
+    if (elements.resetButton) {
+      elements.resetButton.addEventListener("click", resetView);
+    }
+    if (elements.zoomInButton) {
+      elements.zoomInButton.addEventListener("click", function () {
+        zoomAtCenter(panState.scale * ZOOM_BUTTON_FACTOR);
+      });
+    }
+    if (elements.zoomOutButton) {
+      elements.zoomOutButton.addEventListener("click", function () {
+        zoomAtCenter(panState.scale / ZOOM_BUTTON_FACTOR);
+      });
+    }
+    if (elements.copySvgButton) {
+      elements.copySvgButton.addEventListener("click", copySvg);
+    }
+  }
+
+  initialize();
+
+  window.ClaudeMermaidViewer = {
+    config: config,
+    hasSvg: function () {
+      return Boolean(elements.svg);
+    },
+    serializeSvg: serializeSvg,
+  };
+})();

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -167,72 +167,26 @@ export async function handleApiDiagramDelete(context: RouteContext): Promise<voi
   res.end(JSON.stringify({ error: "Not found" }));
 }
 
-/**
- * Static Asset Handlers
- */
-
-export async function handleSharedCss(context: RouteContext): Promise<void> {
-  const { res } = context;
-  try {
-    const { content, contentType, cacheControl } = await serveStaticFile(
-      join(PREVIEW_DIR, ASSET_FILES.SHARED_STYLE),
-      CONTENT_TYPES.CSS
-    );
-    res.writeHead(200, {
-      "Content-Type": contentType,
-      "Cache-Control": cacheControl,
-    });
-    res.end(content);
-  } catch (error) {
-    webLogger.error("Failed to serve shared.css", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    res.writeHead(404, { "Content-Type": CONTENT_TYPES.PLAIN });
-    res.end("Not found");
-  }
+function staticAsset(file: string, contentType: string) {
+  return async ({ res }: RouteContext): Promise<void> => {
+    try {
+      const { content, cacheControl } = await serveStaticFile(join(PREVIEW_DIR, file), contentType);
+      res.writeHead(200, { "Content-Type": contentType, "Cache-Control": cacheControl });
+      res.end(content);
+    } catch (error) {
+      webLogger.error(`Failed to serve ${file}`, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      res.writeHead(404, { "Content-Type": CONTENT_TYPES.PLAIN });
+      res.end("Not found");
+    }
+  };
 }
 
-export async function handleGalleryCss(context: RouteContext): Promise<void> {
-  const { res } = context;
-  try {
-    const { content, contentType, cacheControl } = await serveStaticFile(
-      join(PREVIEW_DIR, ASSET_FILES.GALLERY_STYLE),
-      CONTENT_TYPES.CSS
-    );
-    res.writeHead(200, {
-      "Content-Type": contentType,
-      "Cache-Control": cacheControl,
-    });
-    res.end(content);
-  } catch (error) {
-    webLogger.error("Failed to serve gallery.css", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    res.writeHead(404, { "Content-Type": CONTENT_TYPES.PLAIN });
-    res.end("Not found");
-  }
-}
-
-export async function handleGalleryJs(context: RouteContext): Promise<void> {
-  const { res } = context;
-  try {
-    const { content, contentType, cacheControl } = await serveStaticFile(
-      join(PREVIEW_DIR, ASSET_FILES.GALLERY_SCRIPT),
-      CONTENT_TYPES.JAVASCRIPT
-    );
-    res.writeHead(200, {
-      "Content-Type": contentType,
-      "Cache-Control": cacheControl,
-    });
-    res.end(content);
-  } catch (error) {
-    webLogger.error("Failed to serve gallery.js", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    res.writeHead(404, { "Content-Type": CONTENT_TYPES.PLAIN });
-    res.end("Not found");
-  }
-}
+export const handleSharedCss = staticAsset(ASSET_FILES.SHARED_STYLE, CONTENT_TYPES.CSS);
+export const handleGalleryCss = staticAsset(ASSET_FILES.GALLERY_STYLE, CONTENT_TYPES.CSS);
+export const handleGalleryJs = staticAsset(ASSET_FILES.GALLERY_SCRIPT, CONTENT_TYPES.JAVASCRIPT);
+export const handleViewerJs = staticAsset(ASSET_FILES.VIEWER_SCRIPT, CONTENT_TYPES.JAVASCRIPT);
 
 /**
  * Route Configuration
@@ -250,6 +204,7 @@ export const ROUTE_CONFIG: Route[] = [
   { path: ROUTES.SHARED_STYLE, exact: true, handler: handleSharedCss },
   { path: ROUTES.GALLERY_STYLE, exact: true, handler: handleGalleryCss },
   { path: ROUTES.GALLERY_SCRIPT, exact: true, handler: handleGalleryJs },
+  { path: ROUTES.VIEWER_SCRIPT, exact: true, handler: handleViewerJs },
 ];
 
 /**

--- a/src/tool-definitions.ts
+++ b/src/tool-definitions.ts
@@ -1,0 +1,98 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import {
+  ALLOWED_FORMATS,
+  ALLOWED_THEMES,
+  DEFAULT_FORMAT,
+  DEFAULT_DIAGRAM_OPTIONS,
+} from "./constants.js";
+import type { PreviewBackend } from "./types.js";
+
+export function buildToolDefinitions(previewBackend: PreviewBackend): Tool[] {
+  return [
+    {
+      name: "mermaid_preview",
+      description:
+        `${previewBackend.toolDescription} ` +
+        `Supports themes (${ALLOWED_THEMES.join(", ")}), custom backgrounds, dimensions, and quality scaling. ` +
+        "Use mermaid_save to save to disk. " +
+        "IMPORTANT: Automatically use this tool whenever you create a Mermaid diagram for the user. " +
+        "NOTE: Sequence diagrams do not support style directives - avoid using 'style' statements in sequenceDiagram.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          diagram: {
+            type: "string",
+            description: "The Mermaid diagram code to render",
+          },
+          preview_id: {
+            type: "string",
+            description:
+              "ID for this preview session. Use different IDs for multiple diagrams (e.g., 'architecture', 'flow', 'sequence').",
+          },
+          format: {
+            type: "string",
+            enum: [...ALLOWED_FORMATS],
+            description: `Output format (default: ${DEFAULT_FORMAT})`,
+            default: DEFAULT_FORMAT,
+          },
+          theme: {
+            type: "string",
+            enum: [...ALLOWED_THEMES],
+            description: `Theme of the chart (default: ${DEFAULT_DIAGRAM_OPTIONS.theme})`,
+            default: DEFAULT_DIAGRAM_OPTIONS.theme,
+          },
+          background: {
+            type: "string",
+            description:
+              "Background color for pngs/svgs. Example: transparent, red, '#F0F0F0' (default: white)",
+            default: "white",
+          },
+          width: {
+            type: "number",
+            description: "Diagram width in pixels (default: 800)",
+            default: 800,
+          },
+          height: {
+            type: "number",
+            description: "Diagram height in pixels (default: 600)",
+            default: 600,
+          },
+          scale: {
+            type: "number",
+            description: "Scale factor for higher quality output (default: 2)",
+            default: 2,
+          },
+        },
+        required: ["diagram", "preview_id"],
+      },
+    },
+    {
+      name: "mermaid_save",
+      description:
+        "Save the current live Mermaid diagram to a file path. " +
+        "This copies the already-rendered diagram from the live preview to the specified location. " +
+        "Use this after tuning your diagram with mermaid_preview.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          save_path: {
+            type: "string",
+            description: "Path to save the diagram file (e.g., './docs/diagram.svg')",
+          },
+          preview_id: {
+            type: "string",
+            description:
+              "ID of the preview to save. Must match the preview_id used in mermaid_preview.",
+          },
+          format: {
+            type: "string",
+            enum: [...ALLOWED_FORMATS],
+            description: `Output format (default: ${DEFAULT_FORMAT}). Must match the format used in mermaid_preview.`,
+            default: DEFAULT_FORMAT,
+          },
+        },
+        required: ["save_path", "preview_id"],
+      },
+    },
+  ];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,12 +38,10 @@ export interface DiagramDetails extends DiagramInfo {
 export interface PreviewRequest {
   previewId: string;
   filePath: string;
-  format: string;
   background: string;
 }
 
 export interface PreviewBackend {
-  readonly name: string;
   readonly toolDescription: string;
   present(request: PreviewRequest): Promise<string>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,21 @@ export interface DiagramDetails extends DiagramInfo {
   options: DiagramOptions;
 }
 
+// ===== Preview Backend Types =====
+
+export interface PreviewRequest {
+  previewId: string;
+  filePath: string;
+  format: string;
+  background: string;
+}
+
+export interface PreviewBackend {
+  readonly name: string;
+  readonly toolDescription: string;
+  present(request: PreviewRequest): Promise<string>;
+}
+
 // ===== Route Types =====
 
 export interface RouteContext {

--- a/test/artifact-preview-backend.test.ts
+++ b/test/artifact-preview-backend.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { readFile, writeFile } from "fs/promises";
+import {
+  ArtifactPreviewBackend,
+  buildArtifactPage,
+  toPageTitle,
+} from "../src/artifact-preview-backend.js";
+import { getArtifactPagePath, getDiagramFilePath } from "../src/file-utils.js";
+import { setupTestEnvWithPreview, restoreTestEnv } from "./helpers/env-helpers.js";
+
+const SVG = '<svg xmlns="http://www.w3.org/2000/svg"><text>hello $& world</text></svg>';
+
+describe("toPageTitle", () => {
+  it("turns a kebab or snake case preview id into a readable title", () => {
+    expect(toPageTitle("auth-flow")).toBe("Auth flow");
+    expect(toPageTitle("data_model_v2")).toBe("Data model v2");
+    expect(toPageTitle("architecture")).toBe("Architecture");
+  });
+});
+
+describe("buildArtifactPage", () => {
+  it("inlines the diagram, styles and script into a document fragment", async () => {
+    const page = await buildArtifactPage("auth-flow", SVG, "white");
+
+    expect(page).toContain("<title>Auth flow</title>");
+    expect(page).toContain(SVG);
+    expect(page).toContain('data-diagram-id="auth-flow"');
+    expect(page).toContain('data-live-enabled="false"');
+    expect(page).toContain("background: white");
+    expect(page).toMatch(/<style>[\s\S]*\.viewport[\s\S]*<\/style>/);
+    expect(page).toMatch(/<script>[\s\S]*zoomAtPoint[\s\S]*<\/script>/);
+    expect(page).not.toMatch(/WebSocket|downloadBlob/);
+  });
+
+  it("does not emit a document skeleton or external resources", async () => {
+    const page = await buildArtifactPage("auth-flow", SVG, "white");
+
+    expect(page).not.toMatch(/<!doctype/i);
+    expect(page).not.toMatch(/<html|<head|<body/);
+    expect(page).not.toMatch(/<link\s/);
+    expect(page).not.toMatch(/<script\s+src=/);
+  });
+
+  it("escapes user controlled values", async () => {
+    const page = await buildArtifactPage("auth-flow", SVG, '"><img src=x>');
+
+    expect(page).toContain("background: &quot;&gt;&lt;img src=x&gt;");
+    expect(page).not.toContain('background: "><img');
+  });
+});
+
+describe("ArtifactPreviewBackend", () => {
+  const previewId = "artifact-test";
+
+  beforeEach(async () => {
+    await setupTestEnvWithPreview(previewId);
+  });
+
+  afterEach(async () => {
+    await restoreTestEnv();
+  });
+
+  it("writes the artifact page next to the rendered diagram and reports its path", async () => {
+    const filePath = getDiagramFilePath(previewId, "svg");
+    await writeFile(filePath, SVG, "utf-8");
+
+    const text = await new ArtifactPreviewBackend().present({
+      previewId,
+      filePath,
+      format: "svg",
+      background: "transparent",
+    });
+
+    const pagePath = getArtifactPagePath(previewId);
+    const page = await readFile(pagePath, "utf-8");
+
+    expect(page).toContain(SVG);
+    expect(page).toContain("background: transparent");
+    expect(text).toContain(`Artifact page: ${pagePath}`);
+    expect(text).toContain(`Working file: ${filePath} (SVG)`);
+    expect(text).toMatch(/republish this same path/);
+  });
+});

--- a/test/artifact-preview-backend.test.ts
+++ b/test/artifact-preview-backend.test.ts
@@ -25,7 +25,6 @@ describe("buildArtifactPage", () => {
     expect(page).toContain("<title>Auth flow</title>");
     expect(page).toContain(SVG);
     expect(page).toContain('data-diagram-id="auth-flow"');
-    expect(page).toContain('data-live-enabled="false"');
     expect(page).toContain("background: white");
     expect(page).toMatch(/<style>[\s\S]*\.viewport[\s\S]*<\/style>/);
     expect(page).toMatch(/<script>[\s\S]*zoomAtPoint[\s\S]*<\/script>/);
@@ -67,7 +66,6 @@ describe("ArtifactPreviewBackend", () => {
     const text = await new ArtifactPreviewBackend().present({
       previewId,
       filePath,
-      format: "svg",
       background: "transparent",
     });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { parseCliOptions } from "../src/cli.js";
+
+describe("parseCliOptions", () => {
+  it("defaults to running the MCP server", () => {
+    expect(parseCliOptions([])).toEqual({ version: false, serve: false, preview: undefined });
+  });
+
+  it("recognizes the version flag in long and short form", () => {
+    expect(parseCliOptions(["--version"]).version).toBe(true);
+    expect(parseCliOptions(["-v"]).version).toBe(true);
+  });
+
+  it("recognizes serve mode", () => {
+    expect(parseCliOptions(["--serve"]).serve).toBe(true);
+  });
+
+  it("reads the preview backend value", () => {
+    expect(parseCliOptions(["--preview", "artifact"]).preview).toBe("artifact");
+    expect(parseCliOptions(["--preview=artifact"]).preview).toBe("artifact");
+  });
+
+  it("rejects a preview flag without a value", () => {
+    expect(() => parseCliOptions(["--preview"])).toThrow(/argument missing/);
+    expect(() => parseCliOptions(["--preview", "--serve"])).toThrow(/ambiguous/);
+  });
+
+  it("rejects unknown flags", () => {
+    expect(() => parseCliOptions(["--bogus"])).toThrow(/Unknown option/);
+  });
+});

--- a/test/handlers.test.ts
+++ b/test/handlers.test.ts
@@ -1,10 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { handleMermaidPreview, handleMermaidSave } from "../src/handlers.js";
+import { handleMermaidPreview as previewWithBackend, handleMermaidSave } from "../src/handlers.js";
+import { LiveServerPreviewBackend } from "../src/live-preview-backend.js";
 import { getPreviewDir, getDiagramFilePath, getDiagramOptionsPath } from "../src/file-utils.js";
 import { readdir, unlink, access, writeFile } from "fs/promises";
 import { execFile } from "child_process";
 import { setupTestEnvWithPreview, restoreTestEnv } from "./helpers/env-helpers.js";
 import type { PreviewBackend } from "../src/types.js";
+
+const liveBackend = new LiveServerPreviewBackend();
+const handleMermaidPreview = (args: any, backend: PreviewBackend = liveBackend) =>
+  previewWithBackend(args, backend);
+
+function fakeBackend(text: string): PreviewBackend {
+  return { toolDescription: "fake backend", present: vi.fn(async () => text) };
+}
 
 // Mock child_process to avoid actually running mmdc and opening browser
 vi.mock("child_process", () => ({
@@ -129,7 +138,7 @@ describe("handleMermaidPreview", () => {
       format: "png",
     });
 
-    expect(result.content[0].text).toContain("Live preview is only available for SVG");
+    expect(result.content[0].text).toContain("Preview is only available for SVG");
   });
 
   it("should indicate static render for PDF format", async () => {
@@ -139,7 +148,7 @@ describe("handleMermaidPreview", () => {
       format: "pdf",
     });
 
-    expect(result.content[0].text).toContain("Live preview is only available for SVG");
+    expect(result.content[0].text).toContain("Preview is only available for SVG");
   });
 
   it("should include stderr details in error when rendering fails", async () => {
@@ -278,11 +287,7 @@ describe("handleMermaidPreview with a custom backend", () => {
   });
 
   it("delegates svg previews to the backend and returns its message", async () => {
-    const backend: PreviewBackend = {
-      name: "fake",
-      toolDescription: "fake backend",
-      present: vi.fn(async () => "presented by fake backend"),
-    };
+    const backend = fakeBackend("presented by fake backend");
 
     const result = await handleMermaidPreview(
       { diagram: "graph TD\n A --> B", preview_id: testPreviewId, background: "transparent" },
@@ -293,17 +298,12 @@ describe("handleMermaidPreview with a custom backend", () => {
     expect(backend.present).toHaveBeenCalledWith({
       previewId: testPreviewId,
       filePath: getDiagramFilePath(testPreviewId, "svg"),
-      format: "svg",
       background: "transparent",
     });
   });
 
   it("skips the backend for non-svg formats", async () => {
-    const backend: PreviewBackend = {
-      name: "fake",
-      toolDescription: "fake backend",
-      present: vi.fn(async () => "unexpected"),
-    };
+    const backend = fakeBackend("unexpected");
 
     const result = await handleMermaidPreview(
       { diagram: "graph TD\n A --> B", preview_id: testPreviewId, format: "png" },
@@ -311,7 +311,7 @@ describe("handleMermaidPreview with a custom backend", () => {
     );
 
     expect(backend.present).not.toHaveBeenCalled();
-    expect(result.content[0].text).toContain("Live preview is only available for SVG format");
+    expect(result.content[0].text).toContain("Preview is only available for SVG format");
   });
 });
 

--- a/test/handlers.test.ts
+++ b/test/handlers.test.ts
@@ -4,6 +4,7 @@ import { getPreviewDir, getDiagramFilePath, getDiagramOptionsPath } from "../src
 import { readdir, unlink, access, writeFile } from "fs/promises";
 import { execFile } from "child_process";
 import { setupTestEnvWithPreview, restoreTestEnv } from "./helpers/env-helpers.js";
+import type { PreviewBackend } from "../src/types.js";
 
 // Mock child_process to avoid actually running mmdc and opening browser
 vi.mock("child_process", () => ({
@@ -262,6 +263,55 @@ describe("handleMermaidPreview", () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain(message);
     expect(mockExecFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleMermaidPreview with a custom backend", () => {
+  const testPreviewId = "custom-backend";
+
+  beforeEach(async () => {
+    await setupTestEnvWithPreview(testPreviewId);
+  });
+
+  afterEach(async () => {
+    await restoreTestEnv();
+  });
+
+  it("delegates svg previews to the backend and returns its message", async () => {
+    const backend: PreviewBackend = {
+      name: "fake",
+      toolDescription: "fake backend",
+      present: vi.fn(async () => "presented by fake backend"),
+    };
+
+    const result = await handleMermaidPreview(
+      { diagram: "graph TD\n A --> B", preview_id: testPreviewId, background: "transparent" },
+      backend
+    );
+
+    expect(result.content[0].text).toBe("presented by fake backend");
+    expect(backend.present).toHaveBeenCalledWith({
+      previewId: testPreviewId,
+      filePath: getDiagramFilePath(testPreviewId, "svg"),
+      format: "svg",
+      background: "transparent",
+    });
+  });
+
+  it("skips the backend for non-svg formats", async () => {
+    const backend: PreviewBackend = {
+      name: "fake",
+      toolDescription: "fake backend",
+      present: vi.fn(async () => "unexpected"),
+    };
+
+    const result = await handleMermaidPreview(
+      { diagram: "graph TD\n A --> B", preview_id: testPreviewId, format: "png" },
+      backend
+    );
+
+    expect(backend.present).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain("Live preview is only available for SVG format");
   });
 });
 

--- a/test/handlers.test.ts
+++ b/test/handlers.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { handleMermaidPreview as previewWithBackend, handleMermaidSave } from "../src/handlers.js";
 import { LiveServerPreviewBackend } from "../src/live-preview-backend.js";
-import { getPreviewDir, getDiagramFilePath, getDiagramOptionsPath } from "../src/file-utils.js";
-import { readdir, unlink, access, writeFile } from "fs/promises";
+import { ArtifactPreviewBackend } from "../src/artifact-preview-backend.js";
+import {
+  getPreviewDir,
+  getDiagramFilePath,
+  getDiagramOptionsPath,
+  getArtifactPagePath,
+} from "../src/file-utils.js";
+import { readdir, unlink, access, writeFile, readFile } from "fs/promises";
 import { execFile } from "child_process";
 import { setupTestEnvWithPreview, restoreTestEnv } from "./helpers/env-helpers.js";
 import type { PreviewBackend } from "../src/types.js";
@@ -300,6 +306,20 @@ describe("handleMermaidPreview with a custom backend", () => {
       filePath: getDiagramFilePath(testPreviewId, "svg"),
       background: "transparent",
     });
+  });
+
+  it("writes a complete artifact page through the artifact backend", async () => {
+    const result = await handleMermaidPreview(
+      { diagram: "graph TD\n A --> B", preview_id: testPreviewId },
+      new ArtifactPreviewBackend()
+    );
+
+    const pagePath = getArtifactPagePath(testPreviewId);
+    const page = await readFile(pagePath, "utf-8");
+
+    expect(result.content[0].text).toContain(`Artifact page: ${pagePath}`);
+    expect(page).toContain("<svg>test</svg>");
+    expect(page).not.toMatch(/\{\{\w+\}\}/);
   });
 
   it("skips the backend for non-svg formats", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,77 +2,64 @@ import { describe, it, expect } from "vitest";
 import { readFile } from "fs/promises";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import { ALLOWED_FORMATS, ALLOWED_THEMES } from "../src/constants.js";
+import {
+  ALLOWED_FORMATS,
+  ALLOWED_THEMES,
+  DEFAULT_DIAGRAM_OPTIONS,
+  DEFAULT_FORMAT,
+} from "../src/constants.js";
+import { buildToolDefinitions } from "../src/tool-definitions.js";
+import { LiveServerPreviewBackend } from "../src/live-preview-backend.js";
+import { ArtifactPreviewBackend } from "../src/artifact-preview-backend.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// Load tool definitions from the source by parsing the built output
-// Since index.ts has top-level await and stdio side effects, we parse package.json
-// and validate the tool schema structure against the source file directly.
-const indexSource = await readFile(join(__dirname, "../src/index.ts"), "utf-8");
+const liveTools = buildToolDefinitions(new LiveServerPreviewBackend());
+const preview = liveTools.find((tool) => tool.name === "mermaid_preview")!;
+const save = liveTools.find((tool) => tool.name === "mermaid_save")!;
+const properties = (tool: typeof preview) => tool.inputSchema.properties as Record<string, any>;
 
 describe("MCP server tool definitions", () => {
+  it("defines exactly two tools", () => {
+    expect(liveTools.map((tool) => tool.name)).toEqual(["mermaid_preview", "mermaid_save"]);
+  });
+
   describe("mermaid_preview", () => {
-    it("should be defined with correct name", () => {
-      expect(indexSource).toContain('name: "mermaid_preview"');
+    it("requires diagram and preview_id", () => {
+      expect(preview.inputSchema.required).toEqual(["diagram", "preview_id"]);
     });
 
-    it("should require diagram and preview_id parameters", () => {
-      expect(indexSource).toContain('required: ["diagram", "preview_id"]');
+    it("builds format and theme enums from the allowlists", () => {
+      expect(properties(preview).format.enum).toEqual([...ALLOWED_FORMATS]);
+      expect(properties(preview).theme.enum).toEqual([...ALLOWED_THEMES]);
     });
 
-    it("should build format and theme enums from the allowlists", () => {
-      expect(indexSource).toContain("enum: [...ALLOWED_FORMATS]");
-      expect(indexSource).toContain("enum: [...ALLOWED_THEMES]");
-      expect(ALLOWED_FORMATS).toEqual(["svg", "png", "pdf"]);
-      expect(ALLOWED_THEMES).toEqual(["default", "forest", "dark", "neutral"]);
+    it("defines width, height and scale as numbers with defaults", () => {
+      for (const key of ["width", "height", "scale"] as const) {
+        expect(properties(preview)[key].type).toBe("number");
+        expect(properties(preview)[key].default).toBe(DEFAULT_DIAGRAM_OPTIONS[key]);
+      }
+      expect(properties(preview).format.default).toBe(DEFAULT_FORMAT);
+      expect(properties(preview).theme.default).toBe(DEFAULT_DIAGRAM_OPTIONS.theme);
     });
 
-    it("should define width, height, and scale as number parameters", () => {
-      // These appear in the properties section for mermaid_preview
-      const widthMatch = indexSource.match(/width:\s*\{[^}]*type:\s*"number"/);
-      const heightMatch = indexSource.match(/height:\s*\{[^}]*type:\s*"number"/);
-      const scaleMatch = indexSource.match(/scale:\s*\{[^}]*type:\s*"number"/);
+    it("takes its description from the preview backend", () => {
+      const artifactTools = buildToolDefinitions(new ArtifactPreviewBackend());
+      const artifactPreview = artifactTools.find((tool) => tool.name === "mermaid_preview")!;
 
-      expect(widthMatch).not.toBeNull();
-      expect(heightMatch).not.toBeNull();
-      expect(scaleMatch).not.toBeNull();
-    });
-
-    it("should have default values for optional parameters", () => {
-      expect(indexSource).toContain("default: DEFAULT_FORMAT");
-      expect(indexSource).toContain("default: DEFAULT_DIAGRAM_OPTIONS.theme");
-      expect(indexSource).toContain('default: "white"');
-      expect(indexSource).toContain("default: 800");
-      expect(indexSource).toContain("default: 600");
-      expect(indexSource).toContain("default: 2");
+      expect(preview.description).toContain(new LiveServerPreviewBackend().toolDescription);
+      expect(artifactPreview.description).toContain(new ArtifactPreviewBackend().toolDescription);
+      expect(artifactPreview.description).toContain("mermaid_save");
     });
   });
 
   describe("mermaid_save", () => {
-    it("should be defined with correct name", () => {
-      expect(indexSource).toContain('name: "mermaid_save"');
+    it("requires save_path and preview_id", () => {
+      expect(save.inputSchema.required).toEqual(["save_path", "preview_id"]);
     });
 
-    it("should require save_path and preview_id parameters", () => {
-      expect(indexSource).toContain('required: ["save_path", "preview_id"]');
-    });
-
-    it("should share the format allowlist with mermaid_preview", () => {
-      const formatEnums = indexSource.match(/enum: \[\.\.\.ALLOWED_FORMATS\]/g);
-      expect(formatEnums).not.toBeNull();
-      expect(formatEnums!.length).toBeGreaterThanOrEqual(2);
-    });
-  });
-
-  describe("server configuration", () => {
-    it("should use claude-mermaid as server name", () => {
-      expect(indexSource).toContain('name: "claude-mermaid"');
-    });
-
-    it("should define exactly two tools", () => {
-      const toolNames = indexSource.match(/name: "mermaid_\w+"/g);
-      expect(toolNames).toHaveLength(2);
+    it("shares the format allowlist with mermaid_preview", () => {
+      expect(properties(save).format.enum).toEqual(properties(preview).format.enum);
     });
   });
 });

--- a/test/live-server/basic.test.ts
+++ b/test/live-server/basic.test.ts
@@ -7,7 +7,6 @@ import {
   ensureLiveServer,
   addLiveDiagram,
   hasActiveConnections,
-  escapeHtml,
   closeLiveServer,
 } from "../../src/live-server.js";
 
@@ -81,9 +80,5 @@ describe("Live server basics", () => {
     const id = "new-diagram";
     await addLiveDiagram(id, testFilePath);
     expect(hasActiveConnections(id)).toBe(false);
-  });
-
-  it("escapes HTML entities", () => {
-    expect(escapeHtml("<script>")).toBe("&lt;script&gt;");
   });
 });

--- a/test/live-server/template.test.ts
+++ b/test/live-server/template.test.ts
@@ -35,6 +35,7 @@ describe("Preview template", () => {
 
   it("references CSS and script assets", () => {
     expect(template).toContain('<link rel="stylesheet" href="/style.css"');
+    expect(template).toContain('<script src="/viewer.js"></script>');
     expect(template).toContain('<script src="/script.js"></script>');
   });
 

--- a/test/preview-backend.test.ts
+++ b/test/preview-backend.test.ts
@@ -6,29 +6,21 @@ import { ArtifactPreviewBackend } from "../src/artifact-preview-backend.js";
 
 describe("resolvePreviewBackendName", () => {
   it("defaults to the live server backend", () => {
-    expect(resolvePreviewBackendName([], {})).toBe(PREVIEW_BACKENDS.LIVE);
+    expect(resolvePreviewBackendName(undefined, {})).toBe(PREVIEW_BACKENDS.LIVE);
   });
 
   it("reads the backend from the environment", () => {
     const env = { [PREVIEW_BACKEND_ENV_VAR]: "artifact" };
-    expect(resolvePreviewBackendName([], env)).toBe(PREVIEW_BACKENDS.ARTIFACT);
+    expect(resolvePreviewBackendName(undefined, env)).toBe(PREVIEW_BACKENDS.ARTIFACT);
   });
 
-  it("reads the backend from the --preview flag", () => {
-    expect(resolvePreviewBackendName(["node", "cli", "--preview", "artifact"], {})).toBe(
-      PREVIEW_BACKENDS.ARTIFACT
-    );
-  });
-
-  it("prefers the flag over the environment", () => {
+  it("prefers an explicit request over the environment", () => {
     const env = { [PREVIEW_BACKEND_ENV_VAR]: "artifact" };
-    expect(resolvePreviewBackendName(["node", "cli", "--preview", "live"], env)).toBe(
-      PREVIEW_BACKENDS.LIVE
-    );
+    expect(resolvePreviewBackendName("live", env)).toBe(PREVIEW_BACKENDS.LIVE);
   });
 
   it("rejects unknown backends", () => {
-    expect(() => resolvePreviewBackendName([], { [PREVIEW_BACKEND_ENV_VAR]: "cloud" })).toThrow(
+    expect(() => resolvePreviewBackendName("cloud", {})).toThrow(
       /Invalid preview backend: "cloud"/
     );
   });

--- a/test/preview-backend.test.ts
+++ b/test/preview-backend.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { resolvePreviewBackendName, createPreviewBackend } from "../src/preview-backend.js";
+import { PREVIEW_BACKENDS, PREVIEW_BACKEND_ENV_VAR } from "../src/constants.js";
+
+describe("resolvePreviewBackendName", () => {
+  it("defaults to the live server backend", () => {
+    expect(resolvePreviewBackendName([], {})).toBe(PREVIEW_BACKENDS.LIVE);
+  });
+
+  it("reads the backend from the environment", () => {
+    const env = { [PREVIEW_BACKEND_ENV_VAR]: "artifact" };
+    expect(resolvePreviewBackendName([], env)).toBe(PREVIEW_BACKENDS.ARTIFACT);
+  });
+
+  it("reads the backend from a --preview flag with a separate value", () => {
+    expect(resolvePreviewBackendName(["node", "cli", "--preview", "artifact"], {})).toBe(
+      PREVIEW_BACKENDS.ARTIFACT
+    );
+  });
+
+  it("reads the backend from an inline --preview=value flag", () => {
+    expect(resolvePreviewBackendName(["node", "cli", "--preview=artifact"], {})).toBe(
+      PREVIEW_BACKENDS.ARTIFACT
+    );
+  });
+
+  it("prefers the flag over the environment", () => {
+    const env = { [PREVIEW_BACKEND_ENV_VAR]: "artifact" };
+    expect(resolvePreviewBackendName(["node", "cli", "--preview", "live"], env)).toBe(
+      PREVIEW_BACKENDS.LIVE
+    );
+  });
+
+  it("rejects unknown backends", () => {
+    expect(() => resolvePreviewBackendName([], { [PREVIEW_BACKEND_ENV_VAR]: "cloud" })).toThrow(
+      /Invalid preview backend: "cloud"/
+    );
+  });
+});
+
+describe("createPreviewBackend", () => {
+  it("creates the backend matching the requested name", () => {
+    expect(createPreviewBackend(PREVIEW_BACKENDS.LIVE).name).toBe(PREVIEW_BACKENDS.LIVE);
+    expect(createPreviewBackend(PREVIEW_BACKENDS.ARTIFACT).name).toBe(PREVIEW_BACKENDS.ARTIFACT);
+  });
+
+  it("gives each backend its own tool description", () => {
+    const live = createPreviewBackend(PREVIEW_BACKENDS.LIVE).toolDescription;
+    const artifact = createPreviewBackend(PREVIEW_BACKENDS.ARTIFACT).toolDescription;
+    expect(live).toMatch(/live reload/i);
+    expect(artifact).toMatch(/Artifact tool/);
+    expect(live).not.toBe(artifact);
+  });
+});

--- a/test/preview-backend.test.ts
+++ b/test/preview-backend.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { resolvePreviewBackendName, createPreviewBackend } from "../src/preview-backend.js";
 import { PREVIEW_BACKENDS, PREVIEW_BACKEND_ENV_VAR } from "../src/constants.js";
+import { LiveServerPreviewBackend } from "../src/live-preview-backend.js";
+import { ArtifactPreviewBackend } from "../src/artifact-preview-backend.js";
 
 describe("resolvePreviewBackendName", () => {
   it("defaults to the live server backend", () => {
@@ -12,14 +14,8 @@ describe("resolvePreviewBackendName", () => {
     expect(resolvePreviewBackendName([], env)).toBe(PREVIEW_BACKENDS.ARTIFACT);
   });
 
-  it("reads the backend from a --preview flag with a separate value", () => {
+  it("reads the backend from the --preview flag", () => {
     expect(resolvePreviewBackendName(["node", "cli", "--preview", "artifact"], {})).toBe(
-      PREVIEW_BACKENDS.ARTIFACT
-    );
-  });
-
-  it("reads the backend from an inline --preview=value flag", () => {
-    expect(resolvePreviewBackendName(["node", "cli", "--preview=artifact"], {})).toBe(
       PREVIEW_BACKENDS.ARTIFACT
     );
   });
@@ -40,8 +36,8 @@ describe("resolvePreviewBackendName", () => {
 
 describe("createPreviewBackend", () => {
   it("creates the backend matching the requested name", () => {
-    expect(createPreviewBackend(PREVIEW_BACKENDS.LIVE).name).toBe(PREVIEW_BACKENDS.LIVE);
-    expect(createPreviewBackend(PREVIEW_BACKENDS.ARTIFACT).name).toBe(PREVIEW_BACKENDS.ARTIFACT);
+    expect(createPreviewBackend(PREVIEW_BACKENDS.LIVE)).toBeInstanceOf(LiveServerPreviewBackend);
+    expect(createPreviewBackend(PREVIEW_BACKENDS.ARTIFACT)).toBeInstanceOf(ArtifactPreviewBackend);
   });
 
   it("gives each backend its own tool description", () => {


### PR DESCRIPTION
## Overview

- [x] add a `PreviewBackend` seam in `mermaid_preview`; the live server stays the default
- [x] add an artifact backend that writes a self-contained HTML page per `preview_id` for publishing with the Artifact tool
- [x] select the backend with `--preview artifact` or `CLAUDE_MERMAID_PREVIEW=artifact`; plugin and example configs forward the variable
- [x] split the viewer script (pan, zoom, copy SVG) from live-server-only features and serve it through the route table
- [x] share template filling and diagram page data between the live page and the artifact page
- [x] parse CLI flags with `util.parseArgs` and resolve the backend inside guarded startup
- [x] give the copy button feedback when the clipboard is unavailable
- [x] document artifact mode in the README, changelog, and the mermaid-diagrams skill